### PR TITLE
Added check for replacements.bricks in index.ts

### DIFF
--- a/src/iso/index.ts
+++ b/src/iso/index.ts
@@ -139,7 +139,7 @@ function buildColumn(library, cells, geometries, x, z, gridMetadata) {
             const layout = library.layouts[blocks[y].layout];
             if (layout) {
                 const key = `${x},${y},${z}`;
-                if (replacements && replacements.bricks.has(key))
+                if (replacements && replacements.bricks && replacements.bricks.has(key))
                     continue;
 
                 const block = layout.blocks[blocks[y].block];


### PR DESCRIPTION
OSX 10.13.6, Chrome 80.0.3987.122
I didn't research why, but at the game start, the replacements.bricks are undefined and that causes the game to crash. To workaround it I added a simple check, and now the game works good. Please investigate and create a bug if bricks are never supposed to be undefined. 

```
index.ts:128 Uncaught (in promise) TypeError: Cannot read property 'has' of undefined
    at buildColumn (index.ts:128)
    at loadMesh (index.ts:77)
    at async Object.loadIsometricScenery (index.ts:55)
    at async loadScene (scenes.ts:168)
    at async Object.goto (scenes.ts:87)
buildColumn @ index.ts:128
loadMesh @ index.ts:77
async function (async)
goto @ scenes.ts:87
startNewGameScene @ GameUI.tsx:263
onEnded @ GameUI.tsx:276
keyDownHandler @ keyboard.ts:145
```