### PR TITLE
Feature/convert music files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "build:debug": "cross-env SRCMAP=true NODE_ENV=development webpack -p",
     "lint": "tslint -t msbuild -p ./tsconfig.json",
     "typecheck": "tsc",
-    "convert-video": "ts-node src/utils/convert.ts video"
+    "convert": "ts-node src/utils/convert.ts"
   },
   "repository": "https://github.com/agrande/lba2remake.git",
   "author": "Adrien Grandemange",

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -44,7 +44,7 @@ const videoConvertor = async () => {
 };
 
 const readLanguageTrackFromArguments = () => {
-    if (process.argv.length <= 3) {
+    if (process.argv.length < 4) {
         console.warn('Not specified language. The voice will be in english. ' +
             `Supported languages: ${Object.keys(videoLanguageTracks)}`);
         return videoLanguageTracks['en'];
@@ -57,6 +57,14 @@ const readLanguageTrackFromArguments = () => {
         return videoLanguageTracks['en'];
     }
     return languageTrack;
+};
+
+const readMusicBitrateArguments = () => {
+    if (process.argv.length < 5) {
+        console.warn('Not specified music bitrate. Will use 128k for tracks and 32k for the rest.');
+        return [128, 32];
+    }
+    return [parseInt(process.argv[3], 10), parseInt(process.argv[4], 10)];
 };
 
 const convertToMp4 = async (videoIndex: number, languageTrack: number,
@@ -80,24 +88,43 @@ const musicConvertor = async () => {
     const extensions = {'.wav': 1, '.ogg': 1};
     const filesToConvert = files.filter(file => path.extname(file).toLowerCase() in extensions);
     const size = filesToConvert.length;
+    const bitrates = readMusicBitrateArguments();
     for (let i = 0; i < size; i += 1) {
         const file = filesToConvert[i];
         const inputFile = `${folderPath}${file}`;
-        const outputFile = `${folderPath}${getOutputMusicFileName(file)}`;
-        console.log(`Writing ${outputFile}`);
-        await convertToMp4Audio(inputFile, outputFile);
+        const outputFileName = getOutputMusicFileName(file);
+        const outputFilePath = `${folderPath}${outputFileName}`;
+        const bitrate = getMusicFileBitrate(outputFileName, bitrates);
+        await convertToMp4Audio(inputFile, outputFilePath, bitrate);
     }
 };
 
-const getOutputMusicFileName = (fileName) => {
+const getOutputMusicFileName = (fileName: string) => {
     if (fileName.toLowerCase() === 'lba2.ogg') {
         return 'Track6.mp4';
     }
     return `${path.basename(fileName, path.extname(fileName))}.mp4`;
 };
 
-const convertToMp4Audio = async (inputFilePath: string, outputFilePath: string) => {
-    const command = `rm -f "${outputFilePath}" && ffmpeg -i "${inputFilePath}" -c:a libfdk_aac -b:a 128k "${outputFilePath}"`;
+const getMusicFileBitrate = (fileName: string, bitrates: number[]) => {
+    const higherBitrateFiles = {
+        'tadpcm1.mp4': 1,
+        'tadpcm2.mp4': 1,
+        'tadpcm3.mp4': 1,
+        'tadpcm4.mp4': 1,
+        'tadpcm5.mp4': 1,
+        'track6.mp4': 1
+    };
+    console.log(fileName.toLowerCase(), bitrates);
+    if (fileName.toLowerCase() in higherBitrateFiles) {
+        return bitrates[0];
+    }
+    return bitrates[1];
+};
+
+const convertToMp4Audio = async (inputFilePath: string, outputFilePath: string, bitrate: number) => {
+    console.log(`Converting ${inputFilePath} to ${outputFilePath} with bitrate ${bitrate}k`);
+    const command = `rm -f "${outputFilePath}" && ffmpeg -i "${inputFilePath}" -c:a libfdk_aac -b:a ${bitrate}k "${outputFilePath}"`;
     await executeCommand(command);
 };
 

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -115,7 +115,6 @@ const getMusicFileBitrate = (fileName: string, bitrates: number[]) => {
         'tadpcm5.mp4': 1,
         'track6.mp4': 1
     };
-    console.log(fileName.toLowerCase(), bitrates);
     if (fileName.toLowerCase() in higherBitrateFiles) {
         return bitrates[0];
     }

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -123,7 +123,7 @@ const getMusicFileBitrate = (fileName: string, bitrates: number[]) => {
 
 const convertToMp4Audio = async (inputFilePath: string, outputFilePath: string, bitrate: number) => {
     console.log(`Converting ${inputFilePath} to ${outputFilePath} with bitrate ${bitrate}k`);
-    const command = `rm -f "${outputFilePath}" && ffmpeg -i "${inputFilePath}" -c:a libfdk_aac -b:a ${bitrate}k "${outputFilePath}"`;
+    const command = `rm -f "${outputFilePath}" && ffmpeg -i "${inputFilePath}" -c:a aac -b:a ${bitrate}k "${outputFilePath}"`;
     await executeCommand(command);
 };
 


### PR DESCRIPTION
Can now convert files in data/MUSIC folder. Usage:
`npm run convert music`
or
`npm run convert music 128 32`
where 128 is bitrate for 6 track files while 32 is bitrate for all the rest of the files. Numbers can be any valid bitrate of course. The files that will use first bitrate number are:

```
tadpcm1.mp4
tadpcm2.mp4
tadpcm3.mp4
tadpcm4.mp4
tadpcm5.mp4
track6.mp4

```
If bitrates not specified, 128 and 32 are used by default. 

Copy LBA2.ogg to the MUSIC folder before running convert music. Then this file will be picked up by the script and converted to Track6.mp4

The video convert script should be also now run like
`npm run convert video`
instead of "... convert-video"