### PR TITLE
Fix lba2 theme music stuttering in Chrome.

### DIFF
--- a/utils/convert/convert.ts
+++ b/utils/convert/convert.ts
@@ -101,6 +101,20 @@ const musicConvertor = async () => {
         const inputFile = `${folderPath}${file}`;
         const outputFileName = getOutputMusicFileName(file);
         const outputFilePath = `${folderPath}${outputFileName}`;
+
+        if (file.toLowerCase().endsWith("ogg")) {
+            // For some reason using FFMPEG to directly convert from ogg to aac
+            // causes the web audio API implementation in Chrome to stutter
+            // when playing back the audio. To get around this, first convert
+            // the ogg to a wav, and then run the usual m4a conversion on that
+            // resulting wav file...
+            const wavOutputFile = outputFileName.replace("m4a", "wav");
+            await convertToWavAudio(inputFile, wavOutputFile);
+            await convertToM4aAudio(wavOutputFile, outputFilePath, bitrate);
+            removeFile(wavOutputFile);
+            continue;
+        }
+        
         await convertToM4aAudio(inputFile, outputFilePath, bitrate);
     }
 };
@@ -194,6 +208,12 @@ const convertToM4aAudio = async (inputFilePath: string, outputFilePath: string, 
     console.log(`Converting ${inputFilePath} to ${outputFilePath} with bitrate ${bitrate}k`);
     removeFile(outputFilePath);
     FFmpeg.runSync(`-i "${inputFilePath}" -c:a aac -b:a ${bitrate}k "${outputFilePath}"`);
+};
+
+const convertToWavAudio = async (inputFilePath: string, outputFilePath: string) => {
+    console.log(`Converting ${inputFilePath} to ${outputFilePath}`);
+    removeFile(outputFilePath);
+    FFmpeg.runSync(`-i "${inputFilePath}" -c:a pcm_s16le "${outputFilePath}"`);
 };
 
 const convertors = {


### PR DESCRIPTION
Interestingly this wasn't a problem in Firefox... but I managed to track the issue down to the direct conversion of the ogg to aac via ffmpeg. Converting to a wav first, and then to aac resolves the situation and is a straightforward fix (albeit a hacky one).

The problem is in my opinion bad enough ([example video](https://photos.app.goo.gl/v4suaijbXQLWaMqa9)) to warrant the slightly nasty fix here.