### PR TITLE
Set VR support to false if we detect the user device is a mobile.

### DIFF
--- a/src/ui/Root.tsx
+++ b/src/ui/Root.tsx
@@ -48,6 +48,16 @@ export default class Root extends React.Component<RootProps> {
         window.addEventListener('hashchange', this.onHashChange);
         document.addEventListener('displaychangelog', this.openChangeLog);
 
+        // If the device is a mobile don't suggest playing in VR. Whilst Chrome
+        // can technically support "immersive-vr" via Cardboard etc. given no
+        // controllers will be present we don't consider that supported.
+        if (/Mobi|Android/i.test(navigator.userAgent)) {
+            this.setState({
+                loading: false
+            });
+            return;
+        }
+
         // If WebXR is not supported, try loading the Polyfill.
         if (!('xr' in navigator)) {
           new WebXRPolyfill();

--- a/src/ui/Root.tsx
+++ b/src/ui/Root.tsx
@@ -48,19 +48,10 @@ export default class Root extends React.Component<RootProps> {
         window.addEventListener('hashchange', this.onHashChange);
         document.addEventListener('displaychangelog', this.openChangeLog);
 
-        // If the device is a mobile don't suggest playing in VR. Whilst Chrome
-        // can technically support "immersive-vr" via Cardboard etc. given no
-        // controllers will be present we don't consider that supported.
-        if (/Mobi|Android/i.test(navigator.userAgent)) {
-            this.setState({
-                loading: false
-            });
-            return;
-        }
-
         // If WebXR is not supported, try loading the Polyfill.
         if (!('xr' in navigator)) {
-          new WebXRPolyfill();
+          // Don't support mobile devices without controllers i.e. cardboard.
+          new WebXRPolyfill({cardboard: false});
         }
 
         if ('xr' in navigator) {


### PR DESCRIPTION
Tested with a variety of cases:
* My phone now correctly doesn't suggest playing in VR.
* A supported web browser with a VR device attached correctly suggests VR.
* A web browser with no VR devices attached correctly doesn't suggest VR.