### PR TITLE
Specify width and height on root SVG.

### DIFF
--- a/www/editor/icons/locations/island.svg
+++ b/www/editor/icons/locations/island.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="island_icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="225 -225 500 500" style="enable-background:new 225 -225 500 500;" xml:space="preserve">
+	 y="0px" viewBox="225 -225 500 500" style="enable-background:new 225 -225 500 500;" xml:space="preserve" width="40px" height="40px">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#79B1D2;}

--- a/www/editor/icons/locations/moon.svg
+++ b/www/editor/icons/locations/moon.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="moon_icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+	 viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve" width="160px" height="160px">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#38785E;}

--- a/www/editor/icons/locations/twinsun.svg
+++ b/www/editor/icons/locations/twinsun.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="twinsun_icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+	 y="0px" viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve" width="160px" height="160px">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#0405B6;}

--- a/www/editor/icons/locations/undergas.svg
+++ b/www/editor/icons/locations/undergas.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="undergas_icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve">
+	 y="0px" viewBox="0 0 500 500" style="enable-background:new 0 0 500 500;" xml:space="preserve" width="160px" height="160px">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#150B0B;}

--- a/www/editor/icons/locations/zeelish.svg
+++ b/www/editor/icons/locations/zeelish.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="zeelish_icon" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
-	 y="0px" viewBox="0 0 469.77 499.99" style="enable-background:new 0 0 469.77 499.99;" xml:space="preserve">
+	 y="0px" viewBox="0 0 469.77 499.99" style="enable-background:new 0 0 469.77 499.99;" xml:space="preserve" width="160px" height="160px">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#5A4841;}


### PR DESCRIPTION
Firefox won't render SVGs with no width or height specified on the root SVG node, this means the VR teleport menu planet icons don't render for me :( 
See https://bugzilla.mozilla.org/show_bug.cgi?id=700533

I've set the width and height to be the same value as what we actually use these SVGs for.