### PR TITLE
Improve the Twinsen placement logic when transitioning from one scene to another.

### DIFF
--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -30,7 +30,7 @@ const SCENE_ID_TO_NAME = {
     109: 'FRANCO_VILLAGE',
     174: 'FRANCO_NURSERY',
     175: 'FRANCO_ROGER_HOUSE',
-}
+};
 
 // Map from (previous zone, target zone) to offset in bricks.
 // E.g. ZONE_OFFSET_OVERRIDES[CELLAR][TWINSENS_HOUSE] is the offset we should
@@ -38,17 +38,17 @@ const SCENE_ID_TO_NAME = {
 // from the CELLAR.
 // TODO: There are likely more of these needed.
 const ZONE_OFFSET_OVERRIDES = {
-    'TWINSENS_HOUSE': {
-        'CELLAR': 1.25,
+    TWINSENS_HOUSE: {
+        CELLAR: 1.25,
     },
-    'DESERT_ISLAND_TOWN_SQUARE': {
-        'DESERT_ISLAND_TICKET_SHOP': -1.25,
+    DESERT_ISLAND_TOWN_SQUARE: {
+        DESERT_ISLAND_TICKET_SHOP: -1.25,
     },
-    'FRANCO_VILLAGE': {
-        'FRANCO_NURSERY': -1.25,
-        'FRANCO_ROGER_HOUSE': -1.25,
+    FRANCO_VILLAGE: {
+        FRANCO_NURSERY: -1.25,
+        FRANCO_ROGER_HOUSE: -1.25,
     }
-}
+};
 
 export function processZones(game, scene) {
     const hero = scene.actors[0];
@@ -90,8 +90,8 @@ function debugZoneTargetPos(newScene, pos, color) {
 
 function getDistance(pos1, pos2) {
     return Math.sqrt(
-        Math.pow(pos1.x - pos2.x, 2) + 
-        Math.pow(pos1.y - pos2.y, 2) + 
+        Math.pow(pos1.x - pos2.x, 2) +
+        Math.pow(pos1.y - pos2.y, 2) +
         Math.pow(pos1.z - pos2.z, 2)
     );
 }
@@ -103,21 +103,21 @@ function GOTO_SCENE(game, scene, zone, hero) {
     if (!(scene.sideScenes && zone.props.snap in scene.sideScenes)) {
         scene.goto(zone.props.snap).then((newScene) => {
             // Where the zone props put us by default.
-            let initialTargetPos = {
+            const initialTargetPos = {
                 x:  (((0x8000 - zone.props.info2)) * WORLD_SCALE),
                 y:  zone.props.info1 * WORLD_SCALE,
                 z:  (zone.props.info0) * WORLD_SCALE,
             };
 
-            //debugZoneTargetPos(newScene, initialTargetPos, 0x0000ff);
-           
+            // debugZoneTargetPos(newScene, initialTargetPos, 0x0000ff);
+
             // MAX_ZONE_DIST is the farthest away we would consider a TELEPORT
-            // zone "the" matching zone we're looking for. 
-            const MAX_ZONE_DIST = 5*BRICK_SIZE*WORLD_SCALE;
+            // zone "the" matching zone we're looking for.
+            const MAX_ZONE_DIST = 5 * BRICK_SIZE * WORLD_SCALE;
             // DEFAULT_OFFSET is the default offset we "push" Twinsen into the
             // scene to ensure he doesn't clip back into the zone we're close
             // to and immediately re-enter back into the previous scene.
-            const DEFAULT_OFFSET = 0.5*BRICK_SIZE*WORLD_SCALE;
+            const DEFAULT_OFFSET = 0.5 * BRICK_SIZE * WORLD_SCALE;
 
             // Iterate over all of the zones in the new scene to find the
             // matching zone which we want to be placed at. We do this by
@@ -129,11 +129,11 @@ function GOTO_SCENE(game, scene, zone, hero) {
             let closestZone = null;
             let smallestDistance = Number.MAX_SAFE_INTEGER;
             for (const newZone of newScene.zones) {
-                if (newZone.zoneType != "TELEPORT") {
+                if (newZone.zoneType !== 'TELEPORT') {
                     continue;
                 }
 
-                let newZonePos = {
+                const newZonePos = {
                     x: newZone.props.pos[0],
                     y: newZone.props.pos[1],
                     z: newZone.props.pos[2]
@@ -144,7 +144,7 @@ function GOTO_SCENE(game, scene, zone, hero) {
                     closestZone = newZone;
                 }
             }
-            
+
             // delta represents Twinsens position along the zone. E.g. if
             // Twinsen enters a door on one side, we want the position we place
             // him in the new scene to also be on the same side and "line up".
@@ -154,18 +154,18 @@ function GOTO_SCENE(game, scene, zone, hero) {
             let delta = 0.0;
             // Work out which orientation the zone is, depending on this we can
             // determine which axis should be used to work out how far "along
-            // the zone" Twinsen is. 
+            // the zone" Twinsen is.
             const lenX = zone.props.box.xMax - zone.props.box.xMin;
             const lenZ = zone.props.box.zMax - zone.props.box.zMin;
             if (lenX > lenZ) {
-                delta = (hero.physics.position.x - zone.props.box.xMin)/lenX;
+                delta = (hero.physics.position.x - zone.props.box.xMin) / lenX;
             } else {
-                delta = (hero.physics.position.z - zone.props.box.zMin)/lenZ;
+                delta = (hero.physics.position.z - zone.props.box.zMin) / lenZ;
             }
 
             const newHero = newScene.actors[0];
             if (closestZone) {
-                //console.log("Current scene ID: " + closestZone.props.snap +
+                // console.log("Current scene ID: " + closestZone.props.snap +
                 // " Target scene ID: " + zone.props.snap);
 
                 // offset is how far we push Twinsen into the scene to ensure we
@@ -176,15 +176,15 @@ function GOTO_SCENE(game, scene, zone, hero) {
                 // use that instead.
                 const currentScene = SCENE_ID_TO_NAME[closestZone.props.snap];
                 const targetScene = SCENE_ID_TO_NAME[zone.props.snap];
-                if (ZONE_OFFSET_OVERRIDES[currentScene] && 
+                if (ZONE_OFFSET_OVERRIDES[currentScene] &&
                     ZONE_OFFSET_OVERRIDES[currentScene][targetScene]) {
                     // tslint:disable-next-line:max-line-length
-                    offset = ZONE_OFFSET_OVERRIDES[currentScene][targetScene]*BRICK_SIZE*WORLD_SCALE;
+                    offset = ZONE_OFFSET_OVERRIDES[currentScene][targetScene] * BRICK_SIZE * WORLD_SCALE;
                 }
 
                 // Again work out which orientation the zone is in the new scene
                 // allowing us to know which axis to apply the delta to.
-                const newBox = closestZone.props.box;                
+                const newBox = closestZone.props.box;
                 const newLenX = newBox.xMax - newBox.xMin;
                 const newLenZ = newBox.zMax - newBox.zMin;
                 if (newLenX > newLenZ) {
@@ -193,14 +193,14 @@ function GOTO_SCENE(game, scene, zone, hero) {
                     } else {
                         newHero.physics.position.z = offset + newBox.zMax;
                     }
-                    newHero.physics.position.x = delta*newLenX + newBox.xMin;
+                    newHero.physics.position.x = delta * newLenX + newBox.xMin;
                 } else {
                     if (initialTargetPos.x <= closestZone.props.box.xMin) {
                         newHero.physics.position.x = (-offset) + newBox.xMin;
                     } else {
                         newHero.physics.position.x = offset + newBox.xMax;
                     }
-                    newHero.physics.position.z = delta*newLenZ + newBox.zMin;
+                    newHero.physics.position.z = delta * newLenZ + newBox.zMin;
                 }
 
                 // We find that the Y position given in the zone props is much
@@ -212,9 +212,9 @@ function GOTO_SCENE(game, scene, zone, hero) {
                 newHero.physics.position.y = initialTargetPos.y;
                 newHero.physics.position.z = initialTargetPos.z;
             }
-            
+
             newHero.threeObject.position.copy(newHero.physics.position);
-            //debugZoneTargetPos(newScene, newHero.physics.position, 0xffff00);
+            // debugZoneTargetPos(newScene, newHero.physics.position, 0xffff00);
 
             const dAngle = -zone.props.info3 * (Math.PI / 2);
             if (game.controlsState.firstPerson) {

--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { getHtmlColor } from '../../scene';
 import { DirMode } from '../../game/actors';
 import { AnimType } from '../data/animType';
-import { angleTo, angleToRad, getRandom, WORLD_SCALE } from '../../utils/lba';
+import { angleTo, angleToRad, getRandom, WORLD_SCALE, BRICK_SIZE } from '../../utils/lba';
 import { addExtra, ExtraFlag, randomBonus } from '../extras';
 
 function NOP() { }
@@ -19,6 +19,36 @@ export const ZoneOpcode = [
     { opcode: 8, command: 'SPIKE', handler: NOP },
     { opcode: 9, command: 'RAIL', handler: NOP }
 ];
+
+// Readable Scene IDs. Only those transitions we need zone offsets for are
+// listed.
+const SCENE_ID_TO_NAME = {
+    0: 'TWINSENS_HOUSE',
+    1: 'CELLAR',
+    40: 'DESERT_ISLAND_TICKET_SHOP',
+    60: 'DESERT_ISLAND_TOWN_SQUARE',
+    109: 'FRANCO_VILLAGE',
+    174: 'FRANCO_NURSERY',
+    175: 'FRANCO_ROGER_HOUSE',
+}
+
+// Map from (previous zone, target zone) to offset in bricks.
+// E.g. ZONE_OFFSET_OVERRIDES[CELLAR][TWINSENS_HOUSE] is the offset we should
+// apply when placing Twinsen into the TWINSENS_HOUSE scene when transitioning
+// from the CELLAR.
+// TODO: There are likely more of these needed.
+const ZONE_OFFSET_OVERRIDES = {
+    'TWINSENS_HOUSE': {
+        'CELLAR': 1.25,
+    },
+    'DESERT_ISLAND_TOWN_SQUARE': {
+        'DESERT_ISLAND_TICKET_SHOP': -1.25,
+    },
+    'FRANCO_VILLAGE': {
+        'FRANCO_NURSERY': -1.25,
+        'FRANCO_ROGER_HOUSE': -1.25,
+    }
+}
 
 export function processZones(game, scene) {
     const hero = scene.actors[0];
@@ -45,36 +75,146 @@ export function processZones(game, scene) {
 // This is used to show a visual indicator of the target
 // position to which the hero teleports after changing scene
 /*
-function debugZoneTargetPos(newScene, newHero) {
+function debugZoneTargetPos(newScene, pos, color) {
     const axesHelper = new THREE.AxesHelper(5);
-    const geometry = new THREE.SphereGeometry(0.2, 32, 32);
-    const material = new THREE.MeshBasicMaterial({color: 0xffff00});
+    const geometry = new THREE.SphereGeometry(0.05, 32, 32);
+    const material = new THREE.MeshBasicMaterial({color: color});
     const sphere = new THREE.Mesh(geometry, material);
     const helper = new THREE.Object3D();
     helper.add(sphere);
     helper.add(axesHelper);
-    helper.position.copy(newHero.physics.position);
+    helper.position.copy(pos);
     newScene.sceneNode.add(helper);
 }
 */
+
+function getDistance(pos1, pos2) {
+    return Math.sqrt(
+        Math.pow(pos1.x - pos2.x, 2) + 
+        Math.pow(pos1.y - pos2.y, 2) + 
+        Math.pow(pos1.z - pos2.z, 2)
+    );
+}
 
 /**
  * @return {boolean}
  */
 function GOTO_SCENE(game, scene, zone, hero) {
     if (!(scene.sideScenes && zone.props.snap in scene.sideScenes)) {
-        const box = zone.props.box;
         scene.goto(zone.props.snap).then((newScene) => {
-            const newHero = newScene.actors[0];
-            const dx = hero.physics.position.x - box.xMax;
-            const dy = hero.physics.position.y - box.yMin;
-            const dz = hero.physics.position.z - box.zMin;
-            newHero.physics.position.x = dx + (((0x8000 - zone.props.info2) + 512) * WORLD_SCALE);
-            newHero.physics.position.y = dy + (zone.props.info1 * WORLD_SCALE);
-            newHero.physics.position.z = dz + (zone.props.info0 * WORLD_SCALE);
-            newHero.threeObject.position.copy(newHero.physics.position);
+            // Where the zone props put us by default.
+            let initialTargetPos = {
+                x:  (((0x8000 - zone.props.info2)) * WORLD_SCALE),
+                y:  zone.props.info1 * WORLD_SCALE,
+                z:  (zone.props.info0) * WORLD_SCALE,
+            };
 
-            // debugZoneTargetPos(newScene, newHero);
+            //debugZoneTargetPos(newScene, initialTargetPos, 0x0000ff);
+           
+            // MIN_ZONE_DIST is the farthest away we would consider a TELEPORT
+            // zone "the" matching zone we're looking for. 
+            const MIN_DIST = 5*BRICK_SIZE*WORLD_SCALE;
+            // DEFAULT_OFFSET is the default offset we "push" Twinsen into the
+            // scene to ensure he doesn't clip back into the zone we're close
+            // to and immediately re-enter back into the previous scene.
+            const DEFAULT_OFFSET = 0.5*BRICK_SIZE*WORLD_SCALE;
+
+            // Iterate over all of the zones in the new scene to find the
+            // matching zone which we want to be placed at. We do this by
+            // looking for the closest zone to Twinsen with type TELEPORT.
+            // However, there are cases where such a zone doesn't exist and so
+            // we require that the zone must be within 5 bricks of the
+            // initialTargetPos. If there isn't one, we fall back and just using
+            // the initialTargetPos.
+            let closestZone = null;
+            let smallestDistance = Number.MAX_SAFE_INTEGER;
+            for (const newZone of newScene.zones) {
+                if (newZone.zoneType != "TELEPORT") {
+                    continue;
+                }
+
+                let newZonePos = {
+                    x: newZone.props.pos[0],
+                    y: newZone.props.pos[1],
+                    z: newZone.props.pos[2]
+                };
+                const distance = getDistance(initialTargetPos, newZonePos);
+                if (distance < MIN_DIST && distance < smallestDistance) {
+                    smallestDistance = distance;
+                    closestZone = newZone;
+                }
+            }
+            
+            // delta represents Twinsens position along the zone. E.g. if
+            // Twinsen enters a door on one side, we want the position we place
+            // him in the new scene to also be on the same side and "line up".
+            // delta is a ratio of the length e.g. Twinsen is 10% along the
+            // length of the zone. We have to do this because the matching zone
+            // in the new scene might be a different size to the current one.
+            let delta = 0.0;
+            // Work out which orientation the zone is, depending on this we can
+            // determine which axis should be used to work out how far "along
+            // the zone" Twinsen is. 
+            const lenX = zone.props.box.xMax - zone.props.box.xMin;
+            const lenZ = zone.props.box.zMax - zone.props.box.zMin;
+            if (lenX > lenZ) {
+                delta = (hero.physics.position.x - zone.props.box.xMin)/lenX;
+            } else {
+                delta = (hero.physics.position.z - zone.props.box.zMin)/lenZ;
+            }
+
+            const newHero = newScene.actors[0];
+            if (closestZone) {
+                //console.log("Current scene ID: " + closestZone.props.snap +
+                // " Target scene ID: " + zone.props.snap);
+
+                // offset is how far we push Twinsen into the scene to ensure we
+                // don't immediately re-enter back into the previous scene.
+                let offset = DEFAULT_OFFSET;
+
+                // If we have a specific override for this scene transition,
+                // use that instead.
+                const currentScene = SCENE_ID_TO_NAME[closestZone.props.snap];
+                const targetScene = SCENE_ID_TO_NAME[zone.props.snap];
+                if (ZONE_OFFSET_OVERRIDES[currentScene] && 
+                    ZONE_OFFSET_OVERRIDES[currentScene][targetScene]) {
+                    // tslint:disable-next-line:max-line-length
+                    offset = ZONE_OFFSET_OVERRIDES[currentScene][targetScene]*BRICK_SIZE*WORLD_SCALE;
+                }
+
+                // Again work out which orientation the zone is in the new scene
+                // allowing us to know which axis to apply the delta to.
+                const newBox = closestZone.props.box;                
+                const newLenX = newBox.xMax - newBox.xMin;
+                const newLenZ = newBox.zMax - newBox.zMin;
+                if (newLenX > newLenZ) {
+                    if (initialTargetPos.z <= newBox.zMin) {
+                        newHero.physics.position.z = (-offset) + newBox.zMin;
+                    } else {
+                        newHero.physics.position.z = offset + newBox.zMax;
+                    }
+                    newHero.physics.position.x = delta*newLenX + newBox.xMin;
+                } else {
+                    if (initialTargetPos.x <= closestZone.props.box.xMin) {
+                        newHero.physics.position.x = (-offset) + newBox.xMin;
+                    } else {
+                        newHero.physics.position.x = offset + newBox.xMax;
+                    }
+                    newHero.physics.position.z = delta*newLenZ + newBox.zMin;
+                }
+
+                // We find that the Y position given in the zone props is much
+                // more accurate that the X and Z positions and so we can just
+                // use that here.
+                newHero.physics.position.y = initialTargetPos.y;
+            } else {
+                newHero.physics.position.x = initialTargetPos.x;
+                newHero.physics.position.y = initialTargetPos.y;
+                newHero.physics.position.z = initialTargetPos.z;
+            }
+            
+            newHero.threeObject.position.copy(newHero.physics.position);
+            //debugZoneTargetPos(newScene, newHero.physics.position, 0xffff00);
 
             const dAngle = -zone.props.info3 * (Math.PI / 2);
             if (game.controlsState.firstPerson) {

--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -111,9 +111,9 @@ function GOTO_SCENE(game, scene, zone, hero) {
 
             //debugZoneTargetPos(newScene, initialTargetPos, 0x0000ff);
            
-            // MIN_ZONE_DIST is the farthest away we would consider a TELEPORT
+            // MAX_ZONE_DIST is the farthest away we would consider a TELEPORT
             // zone "the" matching zone we're looking for. 
-            const MIN_DIST = 5*BRICK_SIZE*WORLD_SCALE;
+            const MAX_ZONE_DIST = 5*BRICK_SIZE*WORLD_SCALE;
             // DEFAULT_OFFSET is the default offset we "push" Twinsen into the
             // scene to ensure he doesn't clip back into the zone we're close
             // to and immediately re-enter back into the previous scene.
@@ -139,7 +139,7 @@ function GOTO_SCENE(game, scene, zone, hero) {
                     z: newZone.props.pos[2]
                 };
                 const distance = getDistance(initialTargetPos, newZonePos);
-                if (distance < MIN_DIST && distance < smallestDistance) {
+                if (distance < MAX_ZONE_DIST && distance < smallestDistance) {
                     smallestDistance = distance;
                     closestZone = newZone;
                 }

--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -155,7 +155,6 @@ function calculateTagetPosition(hero, zone, newScene) {
         delta = (hero.physics.position.z - zone.props.box.zMin) / lenZ;
     }
 
-    
     if (closestZone) {
         // console.log("Current scene ID: " + closestZone.props.snap +
         // " Target scene ID: " + zone.props.snap);

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 
+export const BRICK_SIZE = 512;
 export const WORLD_SIZE = 20; // the length of half an outdoors section in meters
 export const WORLD_SCALE = WORLD_SIZE / 0x4000;
 export const WORLD_SCALE_B = 0.03125 * WORLD_SIZE;

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -1,7 +1,9 @@
 import * as THREE from 'three';
 
+// Number of game units equal to a single game brick.
 export const BRICK_SIZE = 512;
-export const WORLD_SIZE = 20; // the length of half an outdoors section in meters
+// The length of half an outdoors section in meters.
+export const WORLD_SIZE = 20; 
 export const WORLD_SCALE = WORLD_SIZE / 0x4000;
 export const WORLD_SCALE_B = 0.03125 * WORLD_SIZE;
 

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 // Number of game units equal to a single game brick.
 export const BRICK_SIZE = 512;
 // The length of half an outdoors section in meters.
-export const WORLD_SIZE = 20; 
+export const WORLD_SIZE = 20;
 export const WORLD_SCALE = WORLD_SIZE / 0x4000;
 export const WORLD_SCALE_B = 0.03125 * WORLD_SIZE;
 


### PR DESCRIPTION
There is some reasonable complexity here so I've done my best to structure it in a nice way and comment it where appropriate.

Basic idea is:
  * Find where the zone.props coordinates would put us by default.
  * Find the closest zone in the new scene to those coordinates (this is the door we're exiting from).
  * If a closest zone doesn't exist, fallback to the default zone.props location.
  * If a closest zone does exist, snap our target location in the new scene to the closest zone bounding box.
  * Apply an offset defaulting to half a brick but allow overriding per scene transition for problematic cases.
  * Apply the delta of Twinsen compared to the door he's entering (i.e. how far along the door he is).

This implementation performs much better that what we currently have. I've spent some time testing and have identified a few offsets for cases which don't work. There are certainly more of these todo but I don't want to spend the time hunting them all down now.