### PR TITLE
Add configurable offset for transparent objects per island.

### DIFF
--- a/src/island/index.ts
+++ b/src/island/index.ts
@@ -256,7 +256,6 @@ function loadSectionPlanes(islandObject, data) {
 
 async function loadGeometries(island, data, ambience) {
     const usedTiles = {};
-
     const models = [];
     const uvGroupsS : Set<string> = new Set();
     const obl = data.files.obl;
@@ -278,7 +277,7 @@ async function loadGeometries(island, data, ambience) {
         const tilesKey = [section.x, section.z].join(',');
         usedTiles[tilesKey] = [];
         loadGround(section, geometries, usedTiles[tilesKey]);
-        loadObjects(section, geometries, models, atlas);
+        loadObjects(section, geometries, models, atlas, island);
     });
 
     return { geometries, usedTiles };

--- a/src/island/objects.ts
+++ b/src/island/objects.ts
@@ -7,11 +7,11 @@ const push = Array.prototype.push;
 
 // Offset amount per island to offset any transparent objects to be closer to
 // the object they're supposed to be attached to. This offset is unfortunately
-// not consistent between islands, although appears to be consistent within a 
+// not consistent between islands, although appears to be consistent within a
 // given island.
 const TransparentObjectOffset = {
-    'CITADEL': 0.05,
-}
+    CITADEL: 0.05,
+};
 
 export function loadObjects(section, geometries, models, atlas, island) {
     const numObjects = section.objInfo.numObjects;
@@ -171,7 +171,7 @@ function getPosition(object, info, index) {
         object.vertices[index * 4] * WORLD_SCALE,
         object.vertices[(index * 4) + 1] * WORLD_SCALE,
         object.vertices[(index * 4) + 2] * WORLD_SCALE
-    ], info.angle);    
+    ], info.angle);
     return [
         pos[0] + info.x,
         pos[1] + info.y,


### PR DESCRIPTION
Transparent objects are placed quite far away from the models they're supposed to be stuck to. E.g. the symbols on the doors on Citadel island. Add a configurable offset per island to push these back to be closer to the object they're supposed to be attached too.

This makes things look much better.

This is actually a problem in the original game, it's just the camera system there doesn't let you get as close as ours and so never looked as bad. However given we allow playing in VR it's much more of a problem for us.