### PR TITLE
Reset jump flag when Twinsen starts climbing.

### DIFF
--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -99,6 +99,9 @@ function LADDER(game, scene, zone, hero) {
         // Is UP being pressed?
         if (game.controlsState.controlVector.y === 1) {
             hero.props.runtimeFlags.isClimbing = true;
+            // Ensure that if Twinsen jumped into the ladder we stop jumping now
+            // that we're climbing.
+            hero.props.runtimeFlags.isJumping = false;
             hero.setAnim(AnimType.CLIMB_UP);
 
             const distFromTop = zone.props.box.yMax - hero.physics.position.y;


### PR DESCRIPTION
This fixes the slight blip at the top of the top out animation if you happened to jump onto the ladder.

I'm pretty sure all climbing up ladder bugs are now fixed!