### PR TITLE
Fix ladders in VR.

### DIFF
--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -97,7 +97,7 @@ function LADDER(game, scene, zone, hero) {
     const facing = isFacingLadder(hero.physics.temp.angle) || scene.isIsland;
     if (zone.props.info1 && facing) {
         // Is UP being pressed?
-        if (game.controlsState.controlVector.y === 1) {
+        if (game.controlsState.controlVector.y > 0.6) {
             hero.props.runtimeFlags.isClimbing = true;
             // Ensure that if Twinsen jumped into the ladder we stop jumping now
             // that we're climbing.


### PR DESCRIPTION
Turned out to be trivial, the control vector is just not exactly 1 for the thumbstick in VR. Be a bit more lenient with how we check for this.