### PR TITLE
Initial implementation for drowning.

### DIFF
--- a/src/game/data/animType.ts
+++ b/src/game/data/animType.ts
@@ -15,6 +15,7 @@ export const AnimType = {
     THROW: 15,
     CROUCH: 16,
     PUNCH_1: 17,
+    DROWNING: 21,
     RUNNING_JUMP: 25,
     TALK: 28,
     DODGE_RIGHT: 40,

--- a/src/game/loop/physicsIsland.ts
+++ b/src/game/loop/physicsIsland.ts
@@ -141,13 +141,18 @@ function processCollisions(sections, scene, obj, _time) {
         }
     }
     obj.props.runtimeFlags.isTouchingGround = isTouchingGround;
+    obj.props.runtimeFlags.isTouchingFloor = getDistFromFloor(sections, scene, obj) < 0.001;
+    if (isTouchingGround && ground.liquid > 0) {
+        obj.props.runtimeFlags.isDrowning = true;
+    }
     return isTouchingGround;
 }
 
 const DEFAULT_GROUND = {
     height: 0,
     sound: null,
-    collision: null
+    collision: null,
+    liquid: 0
 };
 
 const Y_THRESHOLD = WORLD_SIZE / 1600;
@@ -165,7 +170,8 @@ function getGround(section, position) {
             return {
                 height: bb.max.y,
                 sound: null,
-                collision: null
+                collision: null,
+                liquid: 0,
             };
         }
     }

--- a/src/game/loop/physicsIso.ts
+++ b/src/game/loop/physicsIso.ts
@@ -52,6 +52,9 @@ export function processCollisions(grid, _scene, obj, time) {
                 if (newY - position.y < 0.12) {
                     position.y = newY;
                     isTouchingGround = true;
+                    if (column.groundType === GROUND_TYPES.WATER) {
+                        obj.props.runtimeFlags.isDrowning = true;
+                    }
                 }
                 processEscalator(column, position, time);
                 break;

--- a/src/game/scenes.ts
+++ b/src/game/scenes.ts
@@ -105,7 +105,7 @@ export async function createSceneManager(params, game, renderer, hideMenu: Funct
             initSceneDebugData();
             scene.firstFrame = true;
             if (params.editor) {
-                scene.savedState = game.getState().save();
+                scene.savedState = game.getState().save(scene.actors[0]);
             }
             game.loaded(`scene #${index}`, wasPaused);
             return scene;

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -35,18 +35,23 @@ export function createState(): GameState {
             fuel: 0,
             pinguin: 0,
             clover: { boxes: 2, leafs: 1 },
-            magicball: { level: 0, strength: 0, bounce: 0 }
+            magicball: { level: 0, strength: 0, bounce: 0 },
+            position: null,
         },
         chapter: 0,
         flags: {
             quest: createQuestFlags(),
             holomap: createHolomapFlags()
         },
-        save() {
+        save(hero) {
+            this.hero.position = hero.physics.position;
             return JSON.stringify(omit(this, ['save', 'load', 'config']));
         },
-        load(savedState) {
+        load(savedState, hero) {
             const state = JSON.parse(savedState);
+            hero.physics.position.x = state.hero.position.x;
+            hero.physics.position.y = state.hero.position.y;
+            hero.physics.position.z = state.hero.position.z;
             Object.assign(this, state);
         }
     };

--- a/src/island/ground.ts
+++ b/src/island/ground.ts
@@ -127,11 +127,11 @@ function loadTriangleForPhysics(section, x, z, xTgt, zTgt, idx) {
 
     RAY.origin.set(xTgt, 5 * 24, zTgt);
     const tgt = RAY.intersectTriangle(PTS[0], PTS[2], PTS[1], true, TGT);
-
     return {
         sound: bits(flags, 8, 4),
         collision: bits(flags, 17, 1),
-        height: tgt && tgt.y
+        liquid: bits(flags, 12, 4),
+        height: tgt && tgt.y,
     };
 }
 

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -438,7 +438,10 @@ function createRuntimeFlags() {
         isSwitchingHit: false,
         isCrouching: false,
         isClimbing: false,
-        isColliding: false
+        isColliding: false,
+        isDrowning: false,
+        isTouchingGround: false,
+        isTouchingFloor: false,
     };
 }
 


### PR DESCRIPTION
This is only an initial implementation there are still lots of things to follow up here:

- We don't play the correct entity/anim for "drowning" in lava.
- There's a somewhat unrelated bug if you change behaviour when falling which needs looking at.
- Performance wise this isn't great because we're saving the state every frame which involves serialising JSON which is slow. As an initial optimisation I want to only save every 250ms or something which should cut down the impact a lot. Even with the current implementation I don't see any noticeable hit to performance. 
- We should probably move away from the current approach of saving state when we have a more concrete design around saving games in general, saving and recalling just the position like this is a bit of a hack.
- Need to tie this together with the clover system and trigger game over if you die.

That being said this is a working implementation with no issues as far as I can see and works for both islands and iso envs.