### PR TITLE
Fix bug when you get stuck if you change behaviour whilst falling

### DIFF
--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -282,6 +282,9 @@ export async function loadActor(
         },
 
         cancelAnims() {
+            // TODO(scottwilliams): There are likely other cases where we should
+            // also not cancel the animations e.g. when Twinsen is crawling. Add
+            // them here when we've implemented them.
             if (this.props.runtimeFlags.isDrowning) {
                 return;
             }

--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -76,6 +76,7 @@ export interface Actor {
     setBody: Function;
     setAnim: Function;
     setAnimWithCallback: Function;
+    cancelAnims: Function;
 }
 
 export const DirMode = {
@@ -278,6 +279,17 @@ export async function loadActor(
             }
             this.props.animIndex = index;
             this.resetAnimState();
+        },
+
+        cancelAnims() {
+            if (this.props.runtimeFlags.isDrowning) {
+                return;
+            }
+            this.setAnim(0);
+            this.props.runtimeFlags.isJumping = false;
+            this.props.runtimeFlags.isWalking = false;
+            this.props.runtimeFlags.isFalling = false;
+            this.props.runtimeFlags.isClimbing = false;
         },
 
         setAnimWithCallback(index, callback) {

--- a/src/model/animState.ts
+++ b/src/model/animState.ts
@@ -47,6 +47,9 @@ export function resetAnimState(state) {
     state.floorSound = -1;
     state.noInterpolate = false;
     state.interpolationFrame = -1;
+    if (state.callback) {
+        state.callback();
+    }
     state.callback = null;
 }
 

--- a/src/ui/GameUI.tsx
+++ b/src/ui/GameUI.tsx
@@ -295,7 +295,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
             }
             if (key === 'ControlLeft' || key === 'ControlRight' || key === 17) {
                 this.setState({ behaviourMenu: true });
-                if (this.state.scene.actors[0]) {
+                if (!this.state.cinema && this.state.scene.actors[0]) {
                     this.state.scene.actors[0].cancelAnims();
                 }
                 this.state.game.pause();

--- a/src/ui/GameUI.tsx
+++ b/src/ui/GameUI.tsx
@@ -296,7 +296,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
             if (key === 'ControlLeft' || key === 'ControlRight' || key === 17) {
                 this.setState({ behaviourMenu: true });
                 if (this.state.scene.actors[0]) {
-                    this.state.scene.actors[0].cancelAnims();           
+                    this.state.scene.actors[0].cancelAnims();
                 }
                 this.state.game.pause();
             }

--- a/src/ui/GameUI.tsx
+++ b/src/ui/GameUI.tsx
@@ -295,6 +295,9 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
             }
             if (key === 'ControlLeft' || key === 'ControlRight' || key === 17) {
                 this.setState({ behaviourMenu: true });
+                if (this.state.scene.actors[0]) {
+                    this.state.scene.actors[0].cancelAnims();           
+                }
                 this.state.game.pause();
             }
         }


### PR DESCRIPTION
This also makes the ctrl key reset any animation (except drowning) like in the original game. This means you can jump and cancel the jump mid air like you used to be able to do. This is arguably a bug in the original implementation but I feel it was used so much as a core gameplay mechanic for us not to include it in the remake :) 

There are probably a few additional cases where we shouldn't be cancelling the playing animation, I've added a TODO for this so we can add them as we implement them.