### PR TITLE
Only save a valid position every 500ms.

### DIFF
--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -31,7 +31,7 @@ export function updateHero(game, scene, hero, time) {
     } else {
         processActorMovement(game, scene, hero, time, behaviour);
     }
-    
+
     // Only save a valid position at most once every 500ms.
     const timeSinceLastPosSave = performance.now() - game.getState().hero.lastValidPosTime;
     if (validPosition(hero.props.runtimeFlags) && timeSinceLastPosSave > 500) {

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -31,9 +31,12 @@ export function updateHero(game, scene, hero, time) {
     } else {
         processActorMovement(game, scene, hero, time, behaviour);
     }
-
-    if (validPosition(hero.props.runtimeFlags)) {
+    
+    // Only save a valid position at most once every 500ms.
+    const timeSinceLastPosSave = performance.now() - game.getState().hero.lastValidPosTime;
+    if (validPosition(hero.props.runtimeFlags) && timeSinceLastPosSave > 500) {
         scene.savedState = game.getState().save(hero);
+        game.getState().hero.lastValidPosTime = performance.now();
     }
 }
 

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -37,6 +37,7 @@ export function createState(): GameState {
             clover: { boxes: 2, leafs: 1 },
             magicball: { level: 0, strength: 0, bounce: 0 },
             position: null,
+            lastValidPosTime: 0,
         },
         chapter: 0,
         flags: {


### PR DESCRIPTION
This significantly reduces the impact of performance of this approach and also makes some corner cases I've seen less likely where the valid pos we transport you to after drowning actually causes you to instantly drown - by saving the pos 500ms ago it's much more likely the position is further "inland" and so won't trigger that bug.