### PR TITLE
Don't attempt to cancel animations if there is no scene

### DIFF
--- a/src/ui/GameUI.tsx
+++ b/src/ui/GameUI.tsx
@@ -295,7 +295,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
             }
             if (key === 'ControlLeft' || key === 'ControlRight' || key === 17) {
                 this.setState({ behaviourMenu: true });
-                if (!this.state.cinema && this.state.scene.actors[0]) {
+                if (!this.state.cinema && this.state.scene && this.state.scene.actors[0]) {
                     this.state.scene.actors[0].cancelAnims();
                 }
                 this.state.game.pause();


### PR DESCRIPTION
This fixes a null pointer bug if you press control on the main menu for example.