### PR TITLE
Implement jetpack in ISO envs

### DIFF
--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -41,6 +41,9 @@ export function updateHero(game, scene, hero, time) {
 }
 
 function handleBehaviourChanges(scene, hero, behaviour) {
+    if (hero.props.runtimeFlags.isDrowning) {
+        return;
+    }
     if (hero.props.entityIndex !== behaviour) {
         hero.props.entityIndex = behaviour;
         hero.reloadModel(scene);
@@ -105,6 +108,7 @@ function processFirstPersonsMovement(game, scene, hero) {
                 game.getState().load(scene.savedState, hero);
                 hero.setAnim(AnimType.NONE);
                 hero.props.runtimeFlags.isDrowning = false;
+                hero.props.noInterpolateNext = true;
             });
             hero.animState.noInterpolate = true;
             return;
@@ -114,6 +118,7 @@ function processFirstPersonsMovement(game, scene, hero) {
                 game.getState().load(scene.savedState, hero);
                 hero.setAnim(AnimType.NONE);
                 hero.props.runtimeFlags.isDrowningLava = false;
+                hero.props.noInterpolateNext = true;
             });
             hero.animState.noInterpolate = true;
             return;
@@ -246,7 +251,8 @@ function processActorMovement(game, scene, hero, time, behaviour) {
             hero.setAnimWithCallback(AnimType.DROWNING, () => {
                 game.getState().load(scene.savedState, hero);
                 hero.setAnim(AnimType.NONE);
-                hero.props.runtimeFlags.isDrowning = false;
+                hero.props.runtimeFlags.isDrowning = false;     
+                hero.props.noInterpolateNext = true;
             });
             hero.animState.noInterpolate = true;
             return;
@@ -256,6 +262,7 @@ function processActorMovement(game, scene, hero, time, behaviour) {
                 game.getState().load(scene.savedState, hero);
                 hero.setAnim(AnimType.NONE);
                 hero.props.runtimeFlags.isDrowningLava = false;
+                hero.props.noInterpolateNext = true;
             });
             hero.animState.noInterpolate = true;
             return;

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -251,7 +251,7 @@ function processActorMovement(game, scene, hero, time, behaviour) {
             hero.setAnimWithCallback(AnimType.DROWNING, () => {
                 game.getState().load(scene.savedState, hero);
                 hero.setAnim(AnimType.NONE);
-                hero.props.runtimeFlags.isDrowning = false;     
+                hero.props.runtimeFlags.isDrowning = false;
                 hero.props.noInterpolateNext = true;
             });
             hero.animState.noInterpolate = true;

--- a/src/game/loop/physics.ts
+++ b/src/game/loop/physics.ts
@@ -20,8 +20,9 @@ function processActorPhysics(scene, actor, time) {
 
     actor.physics.position.add(actor.physics.temp.position);
     if (actor.props.flags.hasCollisions) {
-        if (!actor.props.runtimeFlags.hasGravityByAnim
-            && actor.props.flags.canFall && !actor.props.runtimeFlags.isClimbing) {
+        if (!actor.props.runtimeFlags.hasGravityByAnim &&
+            actor.props.flags.canFall && !actor.props.runtimeFlags.isClimbing &&
+            !actor.props.runtimeFlags.isUsingProtoOrJetpack) {
             // Max falling speed: 0.15m per frame
             actor.physics.position.y -= 0.25 * WORLD_SIZE * time.delta;
         }

--- a/src/game/loop/physicsIso.ts
+++ b/src/game/loop/physicsIso.ts
@@ -1,82 +1,141 @@
 import * as THREE from 'three';
-import { WORLD_SIZE } from '../../utils/lba';
+import { WORLD_SIZE, getPositions } from '../../utils/lba';
 import { GROUND_TYPES } from '../../iso/grid';
+import { BehaviourMode } from './hero';
+import { AnimType } from '../data/animType';
 
 const STEP = 1 / WORLD_SIZE;
 const ESCALATOR_SPEED = 0.05;
 
+// Vertical height offsets for the jet/protopack.
+const JETPACK_OFFSET = 0.03;
+const PROTOPACK_OFFSET = 0.0075;
+// How fast we reach top vertical height when starting to jetpack.
+const JETPACK_VERTICAL_SPEED = 0.275;
+
+function getColumnY(column, position) {
+    const bb = column.box;
+    switch (column.shape) {
+        case 2:
+            return bb.max.y - ((1 - ((position.z * 32) % 1)) / 64);
+        case 3:
+            return bb.max.y - (((position.x * 32) % 1) / 64);
+        case 4:
+            return bb.max.y - ((1 - ((position.x * 32) % 1)) / 64);
+        case 5:
+            return bb.max.y - (((position.z * 32) % 1) / 64);
+        case 1:
+        default:
+            return bb.max.y;
+    }
+}
+
 export function processCollisions(grid, _scene, obj, time) {
-    let isTouchingGround = false;
+    const isUsingProtoOrJetpack = (obj.props.entityIndex === BehaviourMode.JETPACK ||
+        obj.props.entityIndex === BehaviourMode.PROTOPACK) &&
+        obj.props.animIndex === AnimType.FORWARD;
+
     const basePos = obj.threeObject.position.clone();
     const position = obj.physics.position.clone();
     basePos.multiplyScalar(STEP);
     position.multiplyScalar(STEP);
+
     const dx = 64 - Math.floor(position.x * 32);
     const dz = Math.floor(position.z * 32);
     const cell = grid.cells[(dx * 64) + dz];
+
     if (obj.animState) { // if it's an actor
         obj.floorSound = -1;
     }
+
+    let isTouchingGround = false;
+    let groundHeight = -1;
     if (cell
         && (obj.props.flags.hasCollisionFloor
             || obj.props.flags.canFall)) {
         for (let i = cell.columns.length - 1; i >= 0; i -= 1) {
             const column = cell.columns[i];
             const bb = column.box;
-            let y;
+            const y = getColumnY(column, position);
+
             if (obj.animState) { // if it's an actor
                 obj.animState.floorSound = column.sound;
             }
-            switch (column.shape) {
-                case 2:
-                    y = bb.max.y - ((1 - ((position.z * 32) % 1)) / 64);
-                    break;
-                case 3:
-                    y = bb.max.y - (((position.x * 32) % 1) / 64);
-                    break;
-                case 4:
-                    y = bb.max.y - ((1 - ((position.x * 32) % 1)) / 64);
-                    break;
-                case 5:
-                    y = bb.max.y - (((position.z * 32) % 1) / 64);
-                    break;
-                case 1:
-                default:
-                    y = bb.max.y;
-                    break;
-            }
             const minY = i > 0 ? bb.min.y - (2 * STEP) : -Infinity;
-            obj.props.distFromGround = Math.max(position.y - y, 0) * WORLD_SIZE;
-            if (basePos.y >= minY && position.y < y) {
-                const newY = Math.max(y, position.y);
-                if (newY - position.y < 0.12) {
-                    position.y = newY;
-                    isTouchingGround = true;
-                    switch (column.groundType) {
-                        case GROUND_TYPES.WATER:
-                            obj.props.runtimeFlags.isDrowning = true;
-                            break;
-                        case GROUND_TYPES.LAVA:
-                            obj.props.runtimeFlags.isDrowningLava = true;
-                            break;
+            if (basePos.y >= minY) {
+                groundHeight = y;
+                if (position.y < y) {
+                    const newY = Math.max(y, position.y);
+                    if (newY - position.y < 0.12 && !isUsingProtoOrJetpack) {
+                        position.y = newY;
+                        isTouchingGround = true;
+                        switch (column.groundType) {
+                            case GROUND_TYPES.WATER:
+                                obj.props.runtimeFlags.isDrowning = true;
+                                break;
+                            case GROUND_TYPES.LAVA:
+                                obj.props.runtimeFlags.isDrowningLava = true;
+                                break;
+                        }
                     }
+                    processEscalator(column, position, time);
+                    break;
                 }
-                processEscalator(column, position, time);
-                break;
             }
         }
     }
+
+    let height = groundHeight;
+    if (!isTouchingGround && obj.index === 0) {
+        ACTOR_BOX.copy(obj.model.boundingBox);
+        ACTOR_BOX.min.multiplyScalar(STEP);
+        ACTOR_BOX.max.multiplyScalar(STEP);
+        ACTOR_BOX.translate(position);
+        let floorHeight = null;
+        for (const pos of getPositions(ACTOR_BOX)) {
+            const fh = getFloorHeight(grid, obj, pos);
+            if (floorHeight === null || fh < floorHeight) {
+                floorHeight = fh;
+            }
+        }
+        if (floorHeight > 0) {
+            height = floorHeight;
+        }
+    }
+    obj.props.distFromGround = Math.max(position.y - groundHeight, 0) * WORLD_SIZE;
+    obj.props.distFromFloor = Math.max(position.y - height, 0) * WORLD_SIZE;
+    obj.props.runtimeFlags.isTouchingGround = isTouchingGround;
+    obj.props.runtimeFlags.isUsingProtoOrJetpack = isUsingProtoOrJetpack;
+
+    if (isUsingProtoOrJetpack) {
+        let heightOffset = PROTOPACK_OFFSET;
+        if (obj.props.entityIndex === BehaviourMode.JETPACK) {
+            heightOffset = JETPACK_OFFSET;
+        }
+        if (height - position.y < heightOffset) {
+            const wantHeight = height + heightOffset;
+            const diff = wantHeight - position.y;
+            if (diff <= 0) {
+                position.y -= JETPACK_VERTICAL_SPEED * time.delta;
+                position.y = Math.max(wantHeight, position.y);
+            } else {
+                position.y += JETPACK_VERTICAL_SPEED * time.delta;
+                position.y = Math.min(wantHeight, position.y);
+            }
+        }
+    }
+
     position.y = Math.max(0, position.y);
     if (obj.props.flags.hasCollisionBricks) {
         isTouchingGround = processBoxIntersections(grid, obj, position, dx, dz, isTouchingGround);
     }
     position.multiplyScalar(WORLD_SIZE);
     obj.physics.position.copy(position);
-    obj.props.runtimeFlags.isTouchingGround = isTouchingGround;
 
     return isTouchingGround;
 }
 
+const POSITION = new THREE.Vector3();
 const ACTOR_BOX = new THREE.Box3();
 const INTERSECTION = new THREE.Box3();
 const ITRS_SIZE = new THREE.Vector3();
@@ -84,6 +143,57 @@ const CENTER1 = new THREE.Vector3();
 const CENTER2 = new THREE.Vector3();
 const DIFF = new THREE.Vector3();
 const BB = new THREE.Box3();
+
+function getFloorHeight(grid, actor, position) {
+    POSITION.copy(position);
+
+    const dx = 64 - Math.floor(position.x * 32);
+    const dz = Math.floor(position.z * 32);
+    const groundCell = grid.cells[(dx * 64) + dz];
+
+    while (true) {
+        if (POSITION.y <= -1) {
+            return -1;
+        }
+
+        for (let i = groundCell.columns.length - 1; i >= 0; i -= 1) {
+            const column = groundCell.columns[i];
+            const bb = column.box;
+            const y = getColumnY(column, POSITION);
+            const minY = i > 0 ? bb.min.y - (2 * STEP) : -Infinity;
+            if (POSITION.y >= minY && POSITION.y < y) {
+                if (Math.max(y, POSITION.y) - POSITION.y < 0.12) {
+                    return y;
+                }
+            }
+        }
+
+        ACTOR_BOX.copy(actor.model.boundingBox);
+        ACTOR_BOX.min.multiplyScalar(STEP);
+        ACTOR_BOX.max.multiplyScalar(STEP);
+        ACTOR_BOX.translate(POSITION);
+        DIFF.set(0, 1 / 128, 0);
+        ACTOR_BOX.translate(DIFF);
+        for (let ox = -1; ox < 2; ox += 1) {
+            for (let oz = -1; oz < 2; oz += 1) {
+                const cell = grid.cells[((dx + ox) * 64) + (dz + oz)];
+                if (cell && cell.columns.length > 0) {
+                    for (let i = 0; i < cell.columns.length; i += 1) {
+                        const column = cell.columns[i];
+                        BB.copy(column.box);
+                        if (column.shape !== 1) {
+                            BB.max.y -= STEP;
+                        }
+                        if (ACTOR_BOX.intersectsBox(BB)) {
+                            return BB.max.y;
+                        }
+                    }
+                }
+            }
+        }
+        POSITION.y -= 0.01;
+    }
+}
 
 function processBoxIntersections(grid, actor, position, dx, dz, isTouchingGround) {
     const boundingBox = actor.model.boundingBox;

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -50,6 +50,9 @@ export function createState(): GameState {
         },
         load(savedState, hero) {
             const state = JSON.parse(savedState);
+            if (!state) {
+                return;
+            }
             hero.physics.position.x = state.hero.position.x;
             hero.physics.position.y = state.hero.position.y;
             hero.physics.position.z = state.hero.position.z;

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -443,6 +443,7 @@ function createRuntimeFlags() {
         isDrowningInLava: false,
         isTouchingGround: false,
         isTouchingFloor: false,
+        isUsingProtoOrJetpack: false,
     };
 }
 

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -95,3 +95,14 @@ export function getRandom(min, max) {
 export function getFrequency(frequency) {
     return (frequency * 2) / 100;
 }
+
+// getPositions returns the 4 points that form the bottom face of the provided
+// bounding box.
+export function getPositions(bb) {
+    const positions = [];
+    positions.push(bb.min);
+    positions.push(new THREE.Vector3(bb.min.x, bb.min.y, bb.max.z));
+    positions.push(new THREE.Vector3(bb.max.x, bb.min.y, bb.min.z));
+    positions.push(new THREE.Vector3(bb.max.x, bb.min.y, bb.max.z));
+    return positions;
+}


### PR DESCRIPTION
There are quite a few additional bug fixes here:

- Preserve animState when loading a new scene, this ensures we continue to jetpack correctly into the protection spell cave for example.
- Fix bug with floor height calculation in ISO envs. Before I was using the just the distance to the ground, rather than potential boxes under Twinsen.
- Be slightly more lenient with the fall height in ISO envs when using the protopack this ensures you don't drown if you protopack off the brown tiles in the protection spell cave. I think we've got something slightly off with our ISO collision detection but I see there's a task for that so won't spend more time here.
- Preserve Twinsen's Y value when doing a scene transition, this ensures if we jump through a door we don't just snap Twinsen to the ground.
- Finally, don't allow Twinsen to climb ladders when he's using the jetpack.

Still to fix:

- If you scene transition using the jetpack and then drown we haven't saved a most recent valid position so you get stuck in a drown loop, this should be straightforward to fix, but will do so in a follow up PR.

Let me know if I've missed something, probably have!

**Preview here:** https://pr-326.lba2remake.net