### PR TITLE
Fix actor rotation and a few other minor MOVE script bugs.

### DIFF
--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -150,14 +150,8 @@ export async function loadActor(
         goto(point) {
             this.physics.temp.destination = point;
             let destAngle = angleTo(this.physics.position, point);
-            const signCurr = this.physics.temp.destAngle > 0 ? 1 : -1;
-            const signTgt = destAngle > 0 ? 1 : -1;
-            if (signCurr !== signTgt && Math.abs(destAngle) > Math.PI / 4) {
-                if (signCurr === -1) {
-                    destAngle -= 2 * Math.PI;
-                } else {
-                    destAngle += 2 * Math.PI;
-                }
+            if (destAngle < 0) {
+                destAngle += Math.PI * 2;
             }
             this.physics.temp.destAngle = destAngle;
             this.props.runtimeFlags.isWalking = true;
@@ -173,21 +167,15 @@ export async function loadActor(
 
         facePoint(point) {
             let destAngle = angleTo(this.physics.position, point);
-            const signCurr = this.physics.temp.destAngle > 0 ? 1 : -1;
-            const signTgt = destAngle > 0 ? 1 : -1;
-            if (signCurr !== signTgt && Math.abs(destAngle) > Math.PI / 4) {
-                if (signCurr === -1) {
-                    destAngle -= 2 * Math.PI;
-                } else {
-                    destAngle += 2 * Math.PI;
-                }
+            if (destAngle < 0) {
+                destAngle += Math.PI * 2;
             }
             this.physics.temp.destAngle = destAngle;
             this.props.runtimeFlags.isTurning = true;
         },
 
         setAngle(angle) {
-            // this.props.runtimeFlags.isTurning = true;
+            this.props.runtimeFlags.isTurning = true;
             this.props.angle = angle;
             this.physics.temp.destAngle = angleToRad(angle);
         },

--- a/src/game/loop/actors.ts
+++ b/src/game/loop/actors.ts
@@ -99,10 +99,27 @@ const vrFPsteps = [
 function updateMovements(actor: Actor, firstPerson: boolean, behaviour: number, time: any) {
     const deltaMS = time.delta * 1000;
     if (actor.props.runtimeFlags.isTurning) {
-        const baseAngle = ((actor.physics.temp.destAngle - actor.physics.temp.angle) * deltaMS);
+        const baseAngle = Math.abs((actor.physics.temp.destAngle - actor.physics.temp.angle) * deltaMS);
         let angle = baseAngle / (actor.props.speed * 10);
-        angle = Math.atan2(Math.sin(angle), Math.cos(angle));
-        actor.physics.temp.angle += angle;
+        // We want to rotate in the most efficient way possible, i.e. we rotate
+        // either clockwise or anticlockwise depening on which one is fastest.
+        let distanceAnticlockwise;
+        let distanceClockwise;
+        if (actor.physics.temp.destAngle > actor.physics.temp.angle) {
+            distanceAnticlockwise = Math.abs(actor.physics.temp.destAngle - actor.physics.temp.angle);
+            distanceClockwise = 2 * Math.PI - distanceAnticlockwise;
+        } else {
+            distanceClockwise = Math.abs(actor.physics.temp.destAngle - actor.physics.temp.angle);
+            distanceAnticlockwise =  2 * Math.PI - distanceClockwise;
+        }
+        const sign = distanceAnticlockwise < distanceClockwise ? 1 : -1;
+        actor.physics.temp.angle += sign * angle;
+        if (actor.physics.temp.angle <= 0) {
+            actor.physics.temp.angle += 2 * Math.PI;
+        }
+        if (actor.physics.temp.angle >= 2 * Math.PI) {
+            actor.physics.temp.angle -= 2 * Math.PI;
+        }
         wEuler.set(0, actor.physics.temp.angle, 0, 'XZY');
         actor.physics.orientation.setFromEuler(wEuler);
     }
@@ -133,12 +150,12 @@ function updateMovements(actor: Actor, firstPerson: boolean, behaviour: number, 
 }
 
 function updateModel(game: any,
-                        sceneIsActive: any,
-                        model: any,
-                        animState: any,
-                        entityIdx: number,
-                        animIdx: number,
-                        time: Time) {
+                     sceneIsActive: any,
+                     model: any,
+                     animState: any,
+                     entityIdx: number,
+                     animIdx: number,
+                     time: Time) {
     const entity = model.entities[entityIdx];
     const entityAnim = getAnim(entity, animIdx);
     if (entityAnim !== null) {

--- a/src/game/loop/actors.ts
+++ b/src/game/loop/actors.ts
@@ -99,14 +99,16 @@ const vrFPsteps = [
 function updateMovements(actor: Actor, firstPerson: boolean, behaviour: number, time: any) {
     const deltaMS = time.delta * 1000;
     if (actor.props.runtimeFlags.isTurning) {
-        const baseAngle = Math.abs((actor.physics.temp.destAngle - actor.physics.temp.angle) * deltaMS);
-        let angle = baseAngle / (actor.props.speed * 10);
+        const baseAngle = Math.abs(actor.physics.temp.destAngle -
+                                   actor.physics.temp.angle) * deltaMS;
+        const angle = baseAngle / (actor.props.speed * 10);
         // We want to rotate in the most efficient way possible, i.e. we rotate
         // either clockwise or anticlockwise depening on which one is fastest.
         let distanceAnticlockwise;
         let distanceClockwise;
         if (actor.physics.temp.destAngle > actor.physics.temp.angle) {
-            distanceAnticlockwise = Math.abs(actor.physics.temp.destAngle - actor.physics.temp.angle);
+            distanceAnticlockwise = Math.abs(actor.physics.temp.destAngle -
+                                             actor.physics.temp.angle);
             distanceClockwise = 2 * Math.PI - distanceAnticlockwise;
         } else {
             distanceClockwise = Math.abs(actor.physics.temp.destAngle - actor.physics.temp.angle);

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -14,6 +14,7 @@ export function BODY_OBJ(actor, bodyIndex) {
 
 export function ANIM_OBJ(actor, animIndex) {
     actor.setAnim(animIndex);
+    actor.animState.interpolationFrame = 0;
 }
 
 export const SET_CAMERA = unimplemented();

--- a/src/game/scripting/move.ts
+++ b/src/game/scripting/move.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { unimplemented } from './utils';
-import { WORLD_SCALE, getRandom } from '../../utils/lba';
+import { WORLD_SCALE, getRandom, distAngle } from '../../utils/lba';
 
 export function GOTO_POINT(point) {
     if (this.actor.index === 0 && this.game.controlsState.firstPerson) {
@@ -29,6 +29,12 @@ export function WAIT_ANIM() {
 
 export function ANGLE(angle) {
     this.actor.setAngle(angle);
+    if (distAngle(this.actor.physics.temp.destAngle, this.actor.physics.temp.angle) > Math.PI / 8) {
+        this.state.reentryOffset = this.state.offset;
+        this.state.continue = false;
+    } else {
+        this.actor.stop();
+    }
 }
 
 export const GOTO_SYM_POINT = unimplemented();
@@ -173,10 +179,7 @@ export function SIMPLE_SAMPLE(index) {
 export function FACE_HERO() {
     const hero = this.scene.actors[0];
     this.actor.facePoint(hero.physics.position);
-
-    const distAngle = Math.abs(this.actor.physics.temp.destAngle - this.actor.physics.temp.angle);
-
-    if (distAngle > Math.PI / 8) {
+    if (distAngle(this.actor.physics.temp.destAngle, this.actor.physics.temp.angle) > Math.PI / 8) {
         this.state.reentryOffset = this.state.offset;
         this.state.continue = false;
     } else {

--- a/src/model/animState.ts
+++ b/src/model/animState.ts
@@ -181,7 +181,7 @@ export function updateKeyframeInterpolation(anim, state, time, realAnimIdx) {
 
     let nextFrame = state.loopFrame;
     if (state.interpolationFrame >= 0) {
-        nextFrame = 0;
+        nextFrame = state.interpolationFrame;
     }
     if (state.noInterpolate) {
         state.realAnimIdx = realAnimIdx;

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -71,11 +71,17 @@ export function getDistance(value) {
 export function getDistanceLba(value) {
     return (value * 500) / distanceThreeJs;
 }
+
 export function angleTo(v1, v2) {
     const xdiff = v2.x - v1.x;
     const zdiff = v2.z - v1.z;
 
     return Math.atan2(xdiff, zdiff);
+}
+
+export function distAngle(angle1, angle2) {
+    const clockwiseDist = Math.abs(angle1 - angle2);
+    return Math.min(clockwiseDist, 2 * Math.PI - clockwiseDist);
 }
 
 export function normalizeAngle(angle) {


### PR DESCRIPTION
The main issue was that we weren't turning in the shortest direction, I've changed it so that we look to see if it would be faster to turn anticlockwise or clockwise and then choose the shortest. There were a few other bugs being caused by the animation interpolation code we have so I've disabled interpolation for all script set_anim calls. This matches the original game (as far as I can tell by looking closely at the animations and how they switch).

This fixes the pharmacy issue with the umbrella thief not running out of the door correctly as well as other issues where actors were getting stuck due to not rotating correctly. This hasn't fully fixed the pharmacy scene - there is more work needed here e.g. Miss Amiradoo currently can't run out of the door for some reason. but the big issue is that we don't pause the game whilst text messages are printed on the screen. The original freezes the game and lets the user read the text. By not doing this and letting the move and life scripts progress things get out of sync and then things don't trigger correctly. This is something we'll need to resolve.

**Preview here:** https://pr-341.lba2remake.net