### PR TITLE
Fix non-visible actors collision and distance calculation for GOTO points

### DIFF
--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -3,7 +3,7 @@ import {cloneDeep} from 'lodash';
 
 import { loadModel, Model } from '../model';
 import { loadAnimState, resetAnimState } from '../model/animState';
-import { angleToRad, distance2D, angleTo, getDistanceLba } from '../utils/lba';
+import { angleToRad, distance2D, angleTo, getDistanceLba, getPositions } from '../utils/lba';
 import {createBoundingBox} from '../utils/rendering';
 import { loadSprite } from '../iso/sprites';
 
@@ -96,6 +96,8 @@ export const DirMode = {
     MOVE_BUGGY_MANUAL: 13
 };
 
+const ACTOR_BOX = new THREE.Box3();
+
 // TODO: move section offset to container THREE.Object3D
 export async function loadActor(
     game: any,
@@ -181,6 +183,18 @@ export async function loadActor(
         },
 
         getDistance(pos) {
+            if (this.model) {
+                ACTOR_BOX.copy(this.model.boundingBox);
+                ACTOR_BOX.translate(this.physics.position);
+                let minDist = Infinity;
+                for (const bbPos of getPositions(ACTOR_BOX)) {
+                    const dist = distance2D(bbPos, pos);
+                    if (dist < minDist) {
+                        minDist = dist;
+                    }
+                }
+                return minDist;
+            }
             return distance2D(this.physics.position, pos);
         },
 

--- a/src/game/loop/physics.ts
+++ b/src/game/loop/physics.ts
@@ -86,9 +86,11 @@ function processCollisionsWithActors(scene, actor) {
         if ((a.model === null && a.sprite === null)
             || a.index === actor.index
             || a.isKilled
+            || !a.isVisible
             || !(a.props.flags.hasCollisions || a.props.flags.isSprite)) {
             continue;
         }
+
         const boundingBox = a.model ? a.model.boundingBox : a.sprite.boundingBox;
         INTERSECTION.copy(boundingBox);
         if (a.model) {

--- a/src/game/scripting/common.ts
+++ b/src/game/scripting/common.ts
@@ -14,7 +14,7 @@ export function BETA(angle) {
 
 export function NO_BODY() {
     this.actor.props.bodyIndex = -1;
-    this.actor.props.flags.isVisible = false;
+    this.actor.isVisible = false;
     if (this.actor.threeObject) {
         this.actor.threeObject.visible = false;
     }

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -9,6 +9,7 @@ import { getResourcePath } from '../../resources';
 export const PALETTE = unimplemented();
 
 export function BODY_OBJ(actor, bodyIndex) {
+    actor.isVisible = true;
     actor.setBody(this.scene, bodyIndex);
 }
 


### PR DESCRIPTION
This fixes two bugs:

- We were performing collision detection for actors which weren't visible (i.e. having NO_BODY being called).
- We were calculating the distance to a MOVE script GOTO point using the centre of the actor not the edges of the bounding box. This meant that because MissAmiradoo has a bigger bounding box the distance to the centre of the actor was > 0.5 which is the distance we use to check to see if they've hit a flag.

We're now correctly setting the isVisible bool and checking that in the actor collision code and I've changed to calculate the distance by taking the min of each 4 points of the bounding box.

It's a bit weird we have actor.isVisible and actor.flags.isVisible, I've decided to use the former, but let me know if it's important we keep the flag.isVisible in sync too.

**Preview here:** https://pr-343.lba2remake.net