### PR TITLE
Use meta (command) key instead of control on Mac OS for behaviour menu

### DIFF
--- a/src/controls/keyboard.ts
+++ b/src/controls/keyboard.ts
@@ -24,6 +24,10 @@ export function makeKeyboardControls(params: any,
 
 function keyDownHandler(params, game, sceneManager, event) {
     const key = event.code || event.which || event.keyCode;
+    const { behaviourMenu } = game.getUiState();
+    if (behaviourMenu) {
+        return;
+    }
     // console.log(event.code, event.which, event.keyCode);
     switch (key) {
         case 38: // up

--- a/src/ui/GameUI.tsx
+++ b/src/ui/GameUI.tsx
@@ -293,8 +293,10 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
                     this.hideMenu();
                 }
             }
+            const isMac = /^Mac/.test(navigator && navigator.platform);
             if ((!this.state.showMenu || !this.state.inGameMenu) &&
-                (key === 'ControlLeft' || key === 'ControlRight' || key === 17)) {
+                ((!isMac && (key === 'ControlLeft' || key === 'ControlRight' || key === 17))
+                || (isMac && (key === 'MetaLeft' || key === 'MetaRight' || key === 91)))) {
                 this.setState({ behaviourMenu: true });
                 if (!this.state.cinema && this.state.scene && this.state.scene.actors[0]) {
                     this.state.scene.actors[0].cancelAnims();
@@ -306,8 +308,10 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
 
     listenerKeyUp(event) {
         const key = event.code || event.which || event.keyCode;
+        const isMac = /^Mac/.test(navigator && navigator.platform);
         if ((!this.state.showMenu || !this.state.inGameMenu) &&
-            (key === 'ControlLeft' || key === 'ControlRight' || key === 17)) {
+            ((!isMac && (key === 'ControlLeft' || key === 'ControlRight' || key === 17))
+            || (isMac && (key === 'MetaLeft' || key === 'MetaRight' || key === 91)))) {
             this.setState({ behaviourMenu: false });
             this.state.game.resume();
         }

--- a/src/ui/game/BehaviourMenu.tsx
+++ b/src/ui/game/BehaviourMenu.tsx
@@ -123,13 +123,13 @@ const BehaviourMenu = ({ game }: IBehaviourMenuProps) => {
 
     const listener = (event) => {
         let behav = behaviour;
+        let action = false;
         const key = event.code || event.which || event.keyCode;
-        event.preventDefault();
-        event.stopPropagation();
         switch (key) {
             case 37:
             case 'ArrowLeft':
-                 switch (true) {
+                action = true;
+                switch (true) {
                     // Normal 4 behaviour modes.
                     case behav <= BehaviourModeType.DISCRETE:
                         behav -= 1;
@@ -147,6 +147,7 @@ const BehaviourMenu = ({ game }: IBehaviourMenuProps) => {
                 break;
             case 39:
             case 'ArrowRight':
+                action = true;
                 switch (true) {
                     // Normal 4 behaviour modes.
                     case behav <= BehaviourModeType.DISCRETE:
@@ -165,6 +166,7 @@ const BehaviourMenu = ({ game }: IBehaviourMenuProps) => {
                 break;
             case 38:
             case 'ArrowUp':
+                action = true;
                 switch (true) {
                     // Normal 4 behaviour modes.
                     case behav <= BehaviourModeType.DISCRETE:
@@ -181,6 +183,7 @@ const BehaviourMenu = ({ game }: IBehaviourMenuProps) => {
                 break;
             case 40:
             case 'ArrowDown':
+                action = true;
                 switch (true) {
                     // Normal 4 behaviour modes.
                     case behav <= BehaviourModeType.DISCRETE:
@@ -196,6 +199,11 @@ const BehaviourMenu = ({ game }: IBehaviourMenuProps) => {
                 }
                 break;
         }
+        if (action) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
+
         setBehaviour(behav);
         game.getState().hero.behaviour = behav;
     };

--- a/src/ui/game/BehaviourMenu.tsx
+++ b/src/ui/game/BehaviourMenu.tsx
@@ -124,6 +124,8 @@ const BehaviourMenu = ({ game }: IBehaviourMenuProps) => {
     const listener = (event) => {
         let behav = behaviour;
         const key = event.code || event.which || event.keyCode;
+        event.preventDefault();
+        event.stopPropagation();
         switch (key) {
             case 37:
             case 'ArrowLeft':


### PR DESCRIPTION
I tried preventing the default OS shortcuts (switching between desktops) from being triggered, using javascript, but it is not possible. Since most users will have those shortcuts enabled on Mac OS, I think it's better to move the behaviour key to another shortcut.

**Preview here:** https://pr-345.lba2remake.net