### PR TITLE
More fixes for actor rotation.

### DIFF
--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -3,7 +3,7 @@ import {cloneDeep} from 'lodash';
 
 import { loadModel, Model } from '../model';
 import { loadAnimState, resetAnimState } from '../model/animState';
-import { angleToRad, distance2D, angleTo, getDistanceLba, getPositions } from '../utils/lba';
+import { angleToRad, distance2D, angleTo, getDistanceLba } from '../utils/lba';
 import {createBoundingBox} from '../utils/rendering';
 import { loadSprite } from '../iso/sprites';
 
@@ -96,8 +96,6 @@ export const DirMode = {
     MOVE_BUGGY_MANUAL: 13
 };
 
-const ACTOR_BOX = new THREE.Box3();
-
 // TODO: move section offset to container THREE.Object3D
 export async function loadActor(
     game: any,
@@ -183,18 +181,6 @@ export async function loadActor(
         },
 
         getDistance(pos) {
-            if (this.model) {
-                ACTOR_BOX.copy(this.model.boundingBox);
-                ACTOR_BOX.translate(this.physics.position);
-                let minDist = Infinity;
-                for (const bbPos of getPositions(ACTOR_BOX)) {
-                    const dist = distance2D(bbPos, pos);
-                    if (dist < minDist) {
-                        minDist = dist;
-                    }
-                }
-                return minDist;
-            }
             return distance2D(this.physics.position, pos);
         },
 

--- a/src/game/loop/actors.ts
+++ b/src/game/loop/actors.ts
@@ -99,9 +99,6 @@ const vrFPsteps = [
 function updateMovements(actor: Actor, firstPerson: boolean, behaviour: number, time: any) {
     const deltaMS = time.delta * 1000;
     if (actor.props.runtimeFlags.isTurning) {
-        const baseAngle = Math.abs(actor.physics.temp.destAngle -
-                                   actor.physics.temp.angle) * deltaMS;
-        const angle = baseAngle / (actor.props.speed * 10);
         // We want to rotate in the most efficient way possible, i.e. we rotate
         // either clockwise or anticlockwise depening on which one is fastest.
         let distanceAnticlockwise;
@@ -111,19 +108,30 @@ function updateMovements(actor: Actor, firstPerson: boolean, behaviour: number, 
                                              actor.physics.temp.angle);
             distanceClockwise = 2 * Math.PI - distanceAnticlockwise;
         } else {
-            distanceClockwise = Math.abs(actor.physics.temp.destAngle - actor.physics.temp.angle);
+            distanceClockwise = Math.abs(actor.physics.temp.destAngle -
+                                         actor.physics.temp.angle);
             distanceAnticlockwise =  2 * Math.PI - distanceClockwise;
         }
+        const baseAngle = Math.min(distanceAnticlockwise,
+                                 distanceClockwise) * deltaMS;
+        const angle = baseAngle / (actor.props.speed * 10);
         const sign = distanceAnticlockwise < distanceClockwise ? 1 : -1;
         actor.physics.temp.angle += sign * angle;
-        if (actor.physics.temp.angle <= 0) {
+
+        if (actor.physics.temp.angle < 0) {
             actor.physics.temp.angle += 2 * Math.PI;
         }
-        if (actor.physics.temp.angle >= 2 * Math.PI) {
+        if (actor.physics.temp.angle > 2 * Math.PI) {
             actor.physics.temp.angle -= 2 * Math.PI;
         }
+
         wEuler.set(0, actor.physics.temp.angle, 0, 'XZY');
         actor.physics.orientation.setFromEuler(wEuler);
+
+        if (Math.min(distanceAnticlockwise, distanceClockwise) < 0.05) {
+          actor.props.runtimeFlags.isTurning = false;
+          actor.physics.temp.destAngle = actor.physics.temp.angle;
+        }
     }
     if (actor.props.runtimeFlags.isWalking) {
         actor.physics.temp.position.set(0, 0, 0);

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -327,6 +327,7 @@ function processActorMovement(game, scene, hero, time, behaviour) {
             animIndex = AnimType.THROW;
         }
     }
+
     if (!controlsState.relativeToCam && !hero.props.runtimeFlags.isJumping) {
         if (controlsState.controlVector.x !== 0 && !controlsState.crouch) {
             hero.props.runtimeFlags.isCrouching = false;

--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -271,6 +271,9 @@ function calculateTagetPosition(hero, zone, newScene) {
  * @return {boolean}
  */
 function GOTO_SCENE(game, scene, zone, hero) {
+    hero.props.runtimeFlags.isClimbing = false;
+    hero.props.runtimeFlags.isToppingOutUp = false;
+
     if (!(scene.sideScenes && zone.props.snap in scene.sideScenes)) {
         scene.goto(zone.props.snap).then((newScene) => {
             const newPosition = calculateTagetPosition(hero, zone, newScene);

--- a/src/game/scripting/move.ts
+++ b/src/game/scripting/move.ts
@@ -9,8 +9,7 @@ export function GOTO_POINT(point) {
         return;
     }
     const distance = this.actor.goto(point.physics.position);
-
-    if (distance > 0.5) {
+    if (distance > 0.55) {
         this.state.reentryOffset = this.state.offset;
         this.state.continue = false;
     } else {

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -89,7 +89,11 @@ export function normalizeAngle(angle) {
 }
 
 export function angleToRad(angle) {
-    return normalizeAngle(THREE.MathUtils.degToRad(getRotation(angle, 0, 1) - 90));
+    let rads = THREE.MathUtils.degToRad(getRotation(angle, 0, 1) - 90);
+    if (rads < 0) {
+        rads += Math.PI * 2;
+    }
+    return rads;
 }
 
 export function getRandom(min, max) {


### PR DESCRIPTION
This fixes quite a few things:

- Subtle actor rotation speed bug in certain circumstances.
- MissAmiradoo now exits the pharmacy correctly.
- The umbrella thief doesn't get stuck running in circles outside.
- Fixed the really weird bug I show a clip of where Twinsen got stuck rotating really fast when you climb into the museum.
- Stop Twinsen climbing during a scene change, this ensures we don't keep climbing forever.

I reverted my change to use the 3D model bounding box and instead increased the check distance slightly because I found other cases where it was slightly too short. Things seem to all work correctly now.

**Preview here:** https://pr-346.lba2remake.net