### PR TITLE
Don't update other actors when someone is talking.

### DIFF
--- a/src/game/loop/actors.ts
+++ b/src/game/loop/actors.ts
@@ -43,6 +43,12 @@ export function updateActor(
     }
     actor.runScripts(time);
 
+    // Don't update the actor if someone else is talking.
+    const currentTalkingActor = game.getState().actorTalking;
+    if (currentTalkingActor > -1 && currentTalkingActor !== actor.index) {
+        return;
+    }
+
     if (actor.model !== null
         && actor.threeObject
         && (actor.threeObject.visible || actor.index === 0)) {
@@ -113,7 +119,7 @@ function updateMovements(actor: Actor, firstPerson: boolean, behaviour: number, 
             distanceAnticlockwise =  2 * Math.PI - distanceClockwise;
         }
         const baseAngle = Math.min(distanceAnticlockwise,
-                                 distanceClockwise) * deltaMS;
+                                   distanceClockwise) * deltaMS;
         const angle = baseAngle / (actor.props.speed * 10);
         const sign = distanceAnticlockwise < distanceClockwise ? 1 : -1;
         actor.physics.temp.angle += sign * angle;

--- a/src/game/loop/physics.ts
+++ b/src/game/loop/physics.ts
@@ -6,7 +6,7 @@ import { WORLD_SIZE } from '../../utils/lba';
 
 export function processPhysicsFrame(game, scene, time) {
     each(scene.actors, (actor) => {
-        processActorPhysics(scene, actor, time);
+        processActorPhysics(game, scene, actor, time);
     });
     if (scene.isActive) {
         processZones(game, scene);
@@ -14,9 +14,15 @@ export function processPhysicsFrame(game, scene, time) {
     }
 }
 
-function processActorPhysics(scene, actor, time) {
+function processActorPhysics(game, scene, actor, time) {
     if (!actor.model || actor.isKilled)
         return;
+
+    // If someone is talking who isn't this actor, don't process the physics.
+    const currentTalkingActor = game.getState().actorTalking;
+    if (currentTalkingActor > -1 && currentTalkingActor !== actor.index) {
+        return;
+    }
 
     actor.physics.position.add(actor.physics.temp.position);
     if (actor.props.flags.hasCollisions) {

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -113,7 +113,6 @@ export function MESSAGE_OBJ(cmdState, actor, id) {
     if (cmdState.ended) {
         audio.stopVoice();
         this.game.getState().actorTalking = -1;
-        const text = this.scene.data.texts[id];
         if (text.type !== 9) {
             this.game.setUiState({ text: null, skip: false, });
             this.game.controlsState.skipListener = null;

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -12,6 +12,8 @@ export interface GameState {
     config: GameConfig;
     hero: any;
     chapter: number;
+    // The actor index who is currently talking.
+    actorTalking: number;
     flags: any;
     save: Function;
     load: Function;
@@ -41,6 +43,7 @@ export function createState(): GameState {
             animState: null,
         },
         chapter: 0,
+        actorTalking: -1,
         flags: {
             quest: createQuestFlags(),
             holomap: createHolomapFlags()


### PR DESCRIPTION
Keep updating the actor who is talking to ensure we play the talking animation so it's clear they're the one talking. This fixes the pharmacy scene which now plays correctly all the way through. There are still some subtle differences (e.g. MissAmiradoo turns to face Twinsen in the original before starting to talk, but we don't do that correctly) but we can fix these later.

Also if a message code runs but someone else is already talking, wait for them to finish before starting.

**Preview here:** https://pr-347.lba2remake.net