### PR TITLE
More complete combat implementation.

### DIFF
--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -58,7 +58,6 @@ export interface Actor {
     animState: any;
     isVisible: boolean;
     isSprite: boolean;
-    isKilled: boolean;
     runScripts?: Function;
     loadMesh: Function;
     reloadModel: Function;
@@ -115,7 +114,6 @@ export async function loadActor(
         index: props.index,
         props: cloneDeep(props),
         physics: initPhysics(props),
-        isKilled: false,
         isVisible: props.flags.isVisible
             && (props.life > 0 || props.bodyIndex >= 0)
             && props.index !== 1,
@@ -139,7 +137,7 @@ export async function loadActor(
             this.resetAnimState();
             this.resetPhysics();
             compileScripts(game, scene, this);
-            this.isKilled = false;
+            this.props.runtimeFlags.isDead = false;
             this.floorSound = -1;
         },
 
@@ -327,7 +325,6 @@ export async function loadActor(
                 // TODO(scottwilliams): This doesn't do the right thing for
                 // Twinsen yet.
                 this.props.life = 0;
-                this.isKilled = true;
                 this.props.runtimeFlags.isDead = true;
                 this.isVisible = false;
                 if (this.threeObject) {

--- a/src/game/actors.ts
+++ b/src/game/actors.ts
@@ -313,11 +313,19 @@ export async function loadActor(
                 return;
             }
 
+            let life = -1;
             // TODO(scottwilliams): This doesn't take into account actor armour.
-            this.props.life -= hitStrength;
-            if (this.props.life <= 0) {
-                // TODO(scottwilliams): This isn't how this should be done, and
-                // doesn't trigger the correct things e.g. bonuses etc.
+            if (this.index === 0) {
+                game.getState().hero.life -= hitStrength;
+                life = game.getState().hero.life;
+            } else {
+                this.props.life -= hitStrength;
+                life = this.props.life;
+            }
+
+            if (life <= 0) {
+                // TODO(scottwilliams): This doesn't do the right thing for
+                // Twinsen yet.
                 this.props.life = 0;
                 this.isKilled = true;
                 this.props.runtimeFlags.isDead = true;

--- a/src/game/extras.ts
+++ b/src/game/extras.ts
@@ -295,7 +295,7 @@ export function updateExtra(game, scene, extra, time) {
     }
 }
 
-export function randomBonus(type) {
+export function getBonus(type) {
     let spriteIndex = 0;
     const bonus = [];
     for (let b = 0; b < 5; b += 1) {

--- a/src/game/extras.ts
+++ b/src/game/extras.ts
@@ -54,7 +54,6 @@ export interface Extra {
 
     isVisible: boolean;
     isSprite: boolean;
-    isKilled: boolean;
     hasCollidedWithActor: boolean;
 
     loadMesh: Function;
@@ -85,7 +84,6 @@ export async function addExtra(game, scene, position, angle, spriteIndex, bonus,
     const extra: Extra = {
         type: 'extra',
         physics: initPhysics(position, angle),
-        isKilled: false,
         isVisible: true,
         isSprite: (spriteIndex) ? true : false,
         hasCollidedWithActor: false,
@@ -105,6 +103,7 @@ export async function addExtra(game, scene, position, angle, spriteIndex, bonus,
             },
             runtimeFlags: {
                 isTouchingGround: false,
+                isDead: false,
             }
         },
         spriteIndex,
@@ -213,7 +212,7 @@ export function updateExtra(game, scene, extra, time) {
         for (let i = 0; i < scene.actors.length; i += 1) {
             const a = scene.actors[i];
             if ((a.model === null && a.sprite === null)
-                || a.isKilled
+                || a.props.runtimeFlags.isDead
                 || !(a.props.flags.hasCollisions || a.props.flags.isSprite)) {
                 continue;
             }

--- a/src/game/loop/animAction.ts
+++ b/src/game/loop/animAction.ts
@@ -28,8 +28,8 @@ function processHit(actor, hitStrength, game, scene) {
             a.hit(actor.index, hitStrength);
             if (a.isKilled) {
                 game.getAudioManager().playSample(DEATH_SAMPLE);
-                const angle = a.physics.temp.angle - Math.PI / 2;
                 if (a.props.extraType !== undefined) {
+                    const angle = a.physics.temp.angle - Math.PI / 2;
                     addExtra(game, scene, a.physics.position, angle,
                              getBonus(a.props.extraType), a.props.extraAmount,
                              game.getTime()).then((extra) => {

--- a/src/game/loop/animAction.ts
+++ b/src/game/loop/animAction.ts
@@ -20,15 +20,16 @@ const DEATH_SAMPLE = 14;
 
 function processHit(actor, hitStrength, game, scene) {
     for (const a of scene.actors) {
-        if (a.index === actor.index || a.isKilled || !a.isVisible) {
+        if (a.index === actor.index || !a.isVisible ||
+            a.props.runtimeFlags.isDead) {
             continue;
         }
         // TODO(scottwilliams): This doesn't take into account the actor angles.
         if (distance2D(a.physics.position, actor.physics.position) < 1) {
             a.hit(actor.index, hitStrength);
-            if (a.isKilled) {
+            if (a.props.runtimeFlags.isDead) {
                 game.getAudioManager().playSample(DEATH_SAMPLE);
-                if (a.props.extraType !== undefined) {
+                if (a.props.extraType) {
                     const angle = a.physics.temp.angle - Math.PI / 2;
                     addExtra(game, scene, a.physics.position, angle,
                              getBonus(a.props.extraType), a.props.extraAmount,

--- a/src/game/loop/index.ts
+++ b/src/game/loop/index.ts
@@ -88,7 +88,7 @@ function updateScene(params, game, scene, time) {
         }
     });
     each(scene.actors, (actor) => {
-        if (actor.isKilled)
+        if (actor.props.runtimeFlags.isDead)
             return;
         updateActor(params, game, scene, actor, time);
         if (scene.isActive) {

--- a/src/game/loop/physics.ts
+++ b/src/game/loop/physics.ts
@@ -15,7 +15,7 @@ export function processPhysicsFrame(game, scene, time) {
 }
 
 function processActorPhysics(game, scene, actor, time) {
-    if (!actor.model || actor.isKilled)
+    if (!actor.model || actor.props.runtimeFlags.isDead)
         return;
 
     // If someone is talking who isn't this actor, don't process the physics.
@@ -80,7 +80,8 @@ const Y_THRESHOLD = WORLD_SIZE * 0.000625;
 
 function processCollisionsWithActors(scene, actor) {
     actor.hasCollidedWithActor = -1;
-    if (actor.model === null || actor.isKilled || !actor.props.flags.hasCollisions) {
+    if (actor.model === null || actor.props.runtimeFlags.isDead ||
+        !actor.props.flags.hasCollisions) {
         return;
     }
     ACTOR_BOX.copy(actor.model.boundingBox);
@@ -91,7 +92,7 @@ function processCollisionsWithActors(scene, actor) {
         const a = scene.actors[i];
         if ((a.model === null && a.sprite === null)
             || a.index === actor.index
-            || a.isKilled
+            || a.props.runtimeFlags.isDead
             || !a.isVisible
             || !(a.props.flags.hasCollisions || a.props.flags.isSprite)) {
             continue;

--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -3,7 +3,7 @@ import { getHtmlColor } from '../../scene';
 import { DirMode } from '../../game/actors';
 import { AnimType } from '../data/animType';
 import { angleTo, angleToRad, getRandom, WORLD_SCALE, BRICK_SIZE } from '../../utils/lba';
-import { addExtra, ExtraFlag, randomBonus } from '../extras';
+import { addExtra, ExtraFlag, getBonus } from '../extras';
 
 function NOP() { }
 
@@ -384,7 +384,7 @@ function BONUS(game, scene, zone, hero) {
             return false;
         }
 
-        const bonusSprite = randomBonus(zone.props.info0);
+        const bonusSprite = getBonus(zone.props.info0);
 
         let destAngle = angleTo(zone.physics.position, hero.physics.position);
         destAngle += angleToRad(getRandom(0, 300) - 150);

--- a/src/game/scripting/condition.ts
+++ b/src/game/scripting/condition.ts
@@ -16,8 +16,9 @@ export function COL_OBJ(actor) {
 }
 
 export function DISTANCE(actor) {
-    if (!this.scene.isActive && (actor.index === 0 || this.actor.index === 0))
+    if (!this.scene.isActive && (actor.index === 0 || this.actor.index === 0)) {
         return Infinity;
+    }
     if (actor.props.runtimeFlags.isDead) {
         return Infinity;
     }

--- a/src/game/scripting/index.ts
+++ b/src/game/scripting/index.ts
@@ -82,6 +82,5 @@ export function reviveActor(actor, game) {
     actor.scripts.move.context.state.reentryOffset = 0;
     actor.scripts.move.context.state.stopped = true;
     actor.scripts.move.context.state.trackIndex = -1;
-    actor.isKilled = false;
     actor.props.runtimeFlags.isDead = false;
 }

--- a/src/game/scripting/index.ts
+++ b/src/game/scripting/index.ts
@@ -83,4 +83,5 @@ export function reviveActor(actor, game) {
     actor.scripts.move.context.state.stopped = true;
     actor.scripts.move.context.state.trackIndex = -1;
     actor.isKilled = false;
+    actor.props.runtimeFlags.isDead = false;
 }

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -183,7 +183,6 @@ export function SUB_VAR_GAME(index, value) {
 export function KILL_OBJ(actor) {
     actor.props.life = 0;
     actor.props.runtimeFlags.isDead = true;
-    actor.isKilled = true;
     actor.isVisible = false;
     if (actor.threeObject) {
         actor.threeObject.visible = false;
@@ -573,7 +572,7 @@ export function BRUTAL_EXIT() {
     this.state.continue = false;
     this.state.terminated = true;
     this.moveState.terminated = true;
-    this.actor.isKilled = true;
+    this.actor.props.runtimeFlags.isDead = true;
     this.actor.isVisible = false;
 }
 

--- a/src/scene/index.ts
+++ b/src/scene/index.ts
@@ -214,6 +214,7 @@ function loadActors(scene, offset) {
         actor.hitStrength = data.getInt8(offset);
         offset += 1;
         actor.extraType = data.getInt16(offset, true);
+        actor.extraType &= ~1;
         offset += 2;
         actor.angle = data.getInt16(offset, true);
         offset += 2;


### PR DESCRIPTION
- Actors now drop the correct bonus when they die and play the correct death audio sample.
- Use the correct hit strength when actors hit Twinsen, now he takes the correct amount of damage.
- Fix for runtimeFlags.isDead not being correctly set on actor revive.
- Use the correct life value for Twinsen when deciding if an actor is dead or not.

You can now almost fully play the Tralu scene except Ralph gets stuck running through the door due to our iso collision implementation and Twinsen gets stuck walking out of the scene with Zoe for some reason.

**Preview here:** https://pr-355.lba2remake.net