### PR TITLE
Minor iso collision fix

### DIFF
--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -359,6 +359,9 @@ function processActorMovement(game, scene, hero, time, behaviour) {
             if (!controlsState.sideStep) {
                 const euler = new THREE.Euler();
                 euler.setFromQuaternion(hero.physics.orientation, 'YXZ');
+                if (euler.y < -1) {
+                    euler.y += 2 * Math.PI;
+                }
                 hero.physics.temp.angle = euler.y;
                 if (controlsState.controlVector.y === 0) {
                     animIndex = controlsState.controlVector.x === 1

--- a/src/game/loop/physicsIso.ts
+++ b/src/game/loop/physicsIso.ts
@@ -61,7 +61,7 @@ export function processCollisions(grid, scene, obj, time) {
             if (obj.animState) { // if it's an actor
                 obj.animState.floorSound = column.sound;
             }
-            const minY = i > 0 ? bb.min.y - (2 * STEP) : -Infinity;
+            const minY = i > 0 ? bb.min.y : -Infinity;
             if (basePos.y >= minY) {
                 groundHeight = y;
                 if (position.y < y) {
@@ -164,7 +164,7 @@ function getFloorHeight(grid, actor, position) {
             const column = groundCell.columns[i];
             const bb = column.box;
             const y = getColumnY(column, POSITION);
-            const minY = i > 0 ? bb.min.y - (2 * STEP) : -Infinity;
+            const minY = i > 0 ? bb.min.y : -Infinity;
             if (POSITION.y >= minY && POSITION.y < y) {
                 if (Math.max(y, POSITION.y) - POSITION.y < 0.12) {
                     return y;


### PR DESCRIPTION
This fixes the weird jumping / stuttering we see if there are iso bricks above Twinsen's head. This also allows us now to correctly walk up these stairs: https://imgur.com/a/pAKrVZw

I'm not 100% why this 2 * STEP delta is being used in the first place, as far as I can tell I don't break anything by doing this change and it seems to fix a bunch of problems so ¯\_(ツ)_/¯

Also fix a subtle bug where the hero actor angle is being set negative (we should probably be a bit clearer about trying to standardise on either 0-2Pi or -Pi to +Pi). This breaks the facing the camera logic when Twinsen is facing to the left.