### PR TITLE
Load the sound type for objects and fix getGround to return it.

### DIFF
--- a/src/game/loop/physicsIsland.ts
+++ b/src/game/loop/physicsIsland.ts
@@ -24,8 +24,8 @@ function processCameraCollisions(sections, camPosition, groundOffset = 0.15, obj
     const ground = getGroundInfo(section, camPosition);
     camPosition.y = Math.max(ground.height + groundOffset * WORLD_SIZE, camPosition.y);
     if (section) {
-        for (let i = 0; i < section.boundingBoxes.length; i += 1) {
-            const bb = section.boundingBoxes[i];
+        for (let i = 0; i < section.objectInfo.length; i += 1) {
+            const bb = section.objectInfo[i].boundingBox;
             if (bb.containsPoint(camPosition)) {
                 camPosition.y = bb.max.y + objOffset * WORLD_SIZE;
             }
@@ -93,8 +93,8 @@ function getFloorHeight(sections, scene, obj, minFunc, floorThreshold) {
         ACTOR_BOX.copy(obj.model.boundingBox);
         ACTOR_BOX.translate(POSITION);
         const section = findSection(sections, POSITION);
-        for (let i = 0; i < section.boundingBoxes.length; i += 1) {
-            const bb = section.boundingBoxes[i];
+        for (let i = 0; i < section.objectInfo.length; i += 1) {
+            const bb = section.objectInfo[i].boundingBox;
             if (ACTOR_BOX.intersectsBox(bb)) {
                 return bb.max.y;
             }
@@ -223,15 +223,15 @@ function getGround(section, position) {
     if (!section)
         return DEFAULT_GROUND;
 
-    for (let i = 0; i < section.boundingBoxes.length; i += 1) {
-        const bb = section.boundingBoxes[i];
+    for (let i = 0; i < section.objectInfo.length; i += 1) {
+        const bb = section.objectInfo[i].boundingBox;
         if (position.x >= bb.min.x && position.x <= bb.max.x
             && position.z >= bb.min.z && position.z <= bb.max.z
-            && position.y <= bb.max.y && position.y > bb.max.y - Y_THRESHOLD) {
+            && position.y >= bb.min.y && position.y < bb.max.y + Y_THRESHOLD) {
             FLAGS.hitObject = true;
             return {
                 height: bb.max.y,
-                sound: null,
+                sound: section.objectInfo[i].info.soundType,
                 collision: null,
                 liquid: 0,
             };
@@ -265,8 +265,8 @@ function processBoxIntersections(section, actor, position, isTouchingGround) {
     ACTOR_BOX.copy(boundingBox);
     ACTOR_BOX.translate(position);
     let collision = false;
-    for (let i = 0; i < section.boundingBoxes.length; i += 1) {
-        const bb = section.boundingBoxes[i];
+    for (let i = 0; i < section.objectInfo.length; i += 1) {
+        const bb = section.objectInfo[i].boundingBox;
         if (ACTOR_BOX.intersectsBox(bb)) {
             collision = true;
             isTouchingGround = true;

--- a/src/island/environment/lightning.ts
+++ b/src/island/environment/lightning.ts
@@ -158,8 +158,8 @@ function findLightningPosition(lightning, islandSections, {hero, camera}) {
             const ground = getGroundInfo(section, position);
             position.y = ground.height;
             let hitObj = false;
-            for (let i = 0; i < section.boundingBoxes.length; i += 1) {
-                const bb = section.boundingBoxes[i];
+            for (let i = 0; i < section.objectInfo.length; i += 1) {
+                const bb = section.objectInfo[i].boundingBox;
                 if (bb.containsPoint(position)) {
                     position.y = bb.max.y;
                     hitObj = true;

--- a/src/island/index.ts
+++ b/src/island/index.ts
@@ -146,8 +146,8 @@ async function loadIslandNode(params, props, files, lutTexture, ambience) {
     each(data.layout.groundSections, (section) => {
         sections[`${section.x},${section.z}`] = section;
         if (params.editor) {
-            each(section.boundingBoxes, (bb, idx) => {
-                const box = createBoundingBox(bb, new THREE.Vector3(0.9, 0.9, 0.9));
+            each(section.objectInfo, (info, idx) => {
+                const box = createBoundingBox(info.boundingBox, new THREE.Vector3(0.9, 0.9, 0.9));
                 box.name = `[${section.x},${section.z}]:${idx}`;
                 boundingBoxes.add(box);
             });
@@ -213,7 +213,7 @@ async function loadIslandNode(params, props, files, lutTexture, ambience) {
     return {
         props,
         sections: map(layout.groundSections,
-            section => ({x: section.x, z: section.z, boundingBoxes: section.boundingBoxes })),
+            section => ({x: section.x, z: section.z, objectInfo: section.objectInfo })),
         threeObject: islandObject,
         physics: loadIslandPhysics(sections),
 


### PR DESCRIPTION
I worked out that the scene object info contains the soundType int. Load that and ensure getGround correctly returns the object if Twinsen is standing on it. This fixes the crash we see if you were to walk on this pier for example: 

![image](https://user-images.githubusercontent.com/1941311/95024110-fb7c4680-0678-11eb-963c-ca684e51c9ae.png)

This includes a slight refactoring to abstract the object bounding boxes into objectInfo and bundle both the bounding box and other object info (including the soundType).