### PR TITLE
Fix crash when resetting scene

### DIFF
--- a/src/game/scenes.ts
+++ b/src/game/scenes.ts
@@ -271,7 +271,7 @@ async function loadScene(sceneManager, params, game, renderer, sceneMap, index, 
 
         reset() {
             if (params.editor) {
-                game.getState().load(scene.savedState);
+                game.getState().load(scene.savedState, scene.actors[0]);
                 game.setUiState({ text: null, cinema: false });
                 scene.variables = createSceneVariables(scene);
                 each(this.actors, (actor) => {


### PR DESCRIPTION
I think there are quite a few changes to the reset function that @slwilliams introduced for the drowning support that makes it behave differently from what it did before in the script editor, maybe I'll use a distinct function for that.

**Preview here:** https://pr-385.lba2remake.net