### PR TITLE
Editor's window manager rework

### DIFF
--- a/src/ui/Editor.tsx
+++ b/src/ui/Editor.tsx
@@ -59,7 +59,6 @@ interface EditorState {
         max: number,
         node: LayoutNode
     };
-    mainData?: any;
 }
 
 export default class Editor extends React.Component<EditorProps, EditorState> {
@@ -69,7 +68,6 @@ export default class Editor extends React.Component<EditorProps, EditorState> {
         this.updateSeparator = this.updateSeparator.bind(this);
         this.enableSeparator = this.enableSeparator.bind(this);
         this.disableSeparator = this.disableSeparator.bind(this);
-        this.saveMainData = this.saveMainData.bind(this);
 
         const layout = loadLayout(this);
 
@@ -245,8 +243,6 @@ export default class Editor extends React.Component<EditorProps, EditorState> {
             ticker={this.props.ticker}
             split={this.split.bind(this, path)}
             close={path.length > 0 && !node.root ? this.close.bind(this, path) : null}
-            saveMainData={this.saveMainData}
-            mainData={this.state.mainData}
             rootStateHandler={root.stateHandler}
             editor={this}
         />;
@@ -330,27 +326,11 @@ export default class Editor extends React.Component<EditorProps, EditorState> {
 
     selectMainAreaContent(area, options = {}) {
         DebugData.scope = {};
-        if (this.state.mainData && this.state.mainData.state) {
-            const {renderer, game} = this.state.mainData.state;
-            if (renderer) {
-                renderer.dispose();
-            }
-            if (game) {
-                const audio = game.getAudioManager();
-                audio.stopMusic();
-                audio.stopMusicTheme();
-            }
-        }
         this.setState({
-            mainData: undefined,
             layout: loadLayout(this, area.id, options),
             root: area
         });
         localStorage.setItem('editor_mode', area.id);
-    }
-
-    saveMainData(data) {
-        this.setState({mainData: data});
     }
 
     createNewArea(content) {

--- a/src/ui/GameUI.tsx
+++ b/src/ui/GameUI.tsx
@@ -35,10 +35,6 @@ import { loadPoint } from '../game/points';
 import { loadActor, createNewActorProps, initDynamicNewActor } from '../game/actors';
 
 interface GameUIProps extends TickerProps {
-    saveMainData?: Function;
-    mainData?: {
-        canvas: HTMLCanvasElement;
-    };
     params: any;
     sharedState?: any;
     stateHandler?: any;
@@ -92,7 +88,6 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
         this.onRenderZoneRef = this.onRenderZoneRef.bind(this);
         this.onCanvasWrapperRef = this.onCanvasWrapperRef.bind(this);
         this.frame = this.frame.bind(this);
-        this.saveData = this.saveData.bind(this);
         this.onSceneManagerReady = this.onSceneManagerReady.bind(this);
         this.onGameReady = this.onGameReady.bind(this);
         this.onAskChoiceChanged = this.onAskChoiceChanged.bind(this);
@@ -110,44 +105,37 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
         this.textAnimEndedHandler = this.textAnimEndedHandler.bind(this);
         this.noAudioClick = this.noAudioClick.bind(this);
 
-        if (props.mainData) {
-            const state = props.mainData.state;
-            state.game.setUiState = this.setUiState;
-            state.game.getUiState = this.getUiState;
-            this.state = state;
-        } else {
-            const clock = new THREE.Clock(false);
-            const game = createGame(
-                clock,
-                this.setUiState,
-                this.getUiState,
-                props.params,
-            );
+        const clock = new THREE.Clock(false);
+        const game = createGame(
+            clock,
+            this.setUiState,
+            this.getUiState,
+            props.params,
+        );
 
-            this.state = {
-                clock,
-                game,
-                cinema: false,
-                text: null,
-                skip: false,
-                ask: {choices: []},
-                interjections: {},
-                foundObject: null,
-                loading: true,
-                video: null,
-                choice: null,
-                menuTexts: null,
-                showMenu: false,
-                inGameMenu: false,
-                teleportMenu: false,
-                keyHelp: false,
-                behaviourMenu: false,
-                noAudio: !game.getAudioManager().isContextActive(),
-            };
+        this.state = {
+            clock,
+            game,
+            cinema: false,
+            text: null,
+            skip: false,
+            ask: {choices: []},
+            interjections: {},
+            foundObject: null,
+            loading: true,
+            video: null,
+            choice: null,
+            menuTexts: null,
+            showMenu: false,
+            inGameMenu: false,
+            teleportMenu: false,
+            keyHelp: false,
+            behaviourMenu: false,
+            noAudio: !game.getAudioManager().isContextActive(),
+        };
 
-            clock.start();
-            this.preloadPromise = this.preload(game);
-        }
+        clock.start();
+        this.preloadPromise = this.preload(game);
     }
 
     async preload(game) {
@@ -157,21 +145,12 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
     }
 
     setUiState(state) {
-        this.setState(state, this.saveData);
+        this.setState(state);
     }
 
     @pure()
     getUiState() {
         return this.state;
-    }
-
-    saveData() {
-        if (this.props.saveMainData) {
-            this.props.saveMainData({
-                state: this.state,
-                canvas: this.canvas
-            });
-        }
     }
 
     async onRenderZoneRef(renderZoneElem) {
@@ -184,40 +163,36 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
                     renderZoneElem,
                     this.state.sceneManager
                 );
-                this.setState({ controls }, this.saveData);
+                this.setState({ controls });
             }
         }
     }
 
     async onCanvasWrapperRef(canvasWrapperElem) {
         if (!this.canvasWrapperElem && canvasWrapperElem) {
-            if (this.props.mainData) {
-                this.canvas = this.props.mainData.canvas;
-            } else {
-                this.canvas = document.createElement('canvas');
-                const game = this.state.game;
-                const renderer = new Renderer(this.props.params, this.canvas, {}, 'game');
-                const sceneManager = await createSceneManager(
+            this.canvas = document.createElement('canvas');
+            const game = this.state.game;
+            const renderer = new Renderer(this.props.params, this.canvas, {}, 'game');
+            const sceneManager = await createSceneManager(
+                this.props.params,
+                game,
+                renderer,
+                this.hideMenu.bind(this)
+            );
+            renderer.threeRenderer.setAnimationLoop(() => {
+                this.props.ticker.frame();
+            });
+            this.onSceneManagerReady(sceneManager);
+            let controls;
+            if (this.renderZoneElem) {
+                controls = createControls(
                     this.props.params,
                     game,
-                    renderer,
-                    this.hideMenu.bind(this)
+                    this.renderZoneElem,
+                    sceneManager
                 );
-                renderer.threeRenderer.setAnimationLoop(() => {
-                    this.props.ticker.frame();
-                });
-                this.onSceneManagerReady(sceneManager);
-                let controls;
-                if (this.renderZoneElem) {
-                    controls = createControls(
-                        this.props.params,
-                        game,
-                        this.renderZoneElem,
-                        sceneManager
-                    );
-                }
-                this.setState({ renderer, sceneManager, controls }, this.saveData);
             }
+            this.setState({ renderer, sceneManager, controls });
             this.canvasWrapperElem = canvasWrapperElem;
             this.canvasWrapperElem.appendChild(this.canvas);
         }
@@ -264,7 +239,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
         this.state.game.pause();
         const audio = this.state.game.getAudioManager();
         audio.playMusicTheme();
-        this.setState({showMenu: true, inGameMenu}, this.saveData);
+        this.setState({showMenu: true, inGameMenu});
     }
 
     hideMenu(wasPaused = false) {
@@ -272,16 +247,16 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
         audio.stopMusicTheme();
         if (!wasPaused)
             this.state.game.resume();
-        this.setState({showMenu: false, inGameMenu: false}, this.saveData);
+        this.setState({showMenu: false, inGameMenu: false});
         this.canvas.focus();
     }
 
     openKeyHelp() {
-        this.setState({keyHelp: true}, this.saveData);
+        this.setState({keyHelp: true});
     }
 
     closeKeyHelp() {
-        this.setState({keyHelp: false}, this.saveData);
+        this.setState({keyHelp: false});
     }
 
     listenerKeyDown(event) {
@@ -449,7 +424,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
             case 71: { // New Game
                 this.hideMenu();
                 const onEnded = () => {
-                    this.setState({video: null}, this.saveData);
+                    this.setState({video: null});
                     this.startNewGameScene();
                     this.state.game.controlsState.skipListener = null;
                 };
@@ -460,7 +435,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
                         path: getVideoPath('INTRO'),
                         onEnded
                     }
-                }, this.saveData);
+                });
                 break;
             }
             case -1: { // Teleport
@@ -526,7 +501,7 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
             this.checkResize();
             const scene = sceneManager.getScene();
             if (this.state.scene !== scene) {
-                this.setState({scene}, this.saveData);
+                this.setState({scene});
             }
             mainGameLoop(
                 this.props.params,
@@ -574,14 +549,14 @@ export default class GameUI extends FrameListener<GameUIProps, GameUIState> {
                 if (this.state.video) {
                     this.setState({
                         video: clone(this.state.video)
-                    }, this.saveData); // Force video rerender
+                    }); // Force video rerender
                 }
             }
         }
     }
 
     onAskChoiceChanged(choice) {
-        this.setState({choice}, this.saveData);
+        this.setState({choice});
     }
 
     textAnimEndedHandler() {

--- a/src/ui/Root.tsx
+++ b/src/ui/Root.tsx
@@ -122,11 +122,11 @@ export default class Root extends React.Component<RootProps> {
                 content = <GameUI params={this.state.params} ticker={this.props.ticker} />;
             }
         }
-        return <div>
+        return <React.Fragment>
             {content}
             <Popup/>
             {this.state.changelog ?
                 <ChangeLog fullscreen title close={this.closeChangeLog}/> : null}
-        </div>;
+        </React.Fragment>;
     }
 }

--- a/src/ui/editor/Area.tsx
+++ b/src/ui/editor/Area.tsx
@@ -175,6 +175,7 @@ export default class Area extends React.Component<AreaProps, AreaState> {
 
     render() {
         return <div
+            className="editor_area"
             style={this.props.style}
             onKeyDown={this.keyDown}
             tabIndex={0}

--- a/src/ui/editor/Area.tsx
+++ b/src/ui/editor/Area.tsx
@@ -103,8 +103,6 @@ interface AreaProps {
     availableAreas: AreaDefinition[];
     selectAreaContent: (content: AreaDefinition) => void;
     editor: any;
-    saveMainData: Function;
-    mainData: Object;
 }
 
 interface AreaState {
@@ -313,12 +311,6 @@ export default class Area extends React.Component<AreaProps, AreaState> {
             editor: this.props.editor,
             area: this
         };
-        if (this.props.mainArea) {
-            extend(props, {
-                saveMainData: this.props.saveMainData,
-                mainData: this.props.mainData
-            });
-        }
         return <div style={extend({}, contentStyle, this.props.area.style)}>
             {React.createElement(this.props.area.content, props)}
             {this.renderPopup()}

--- a/src/ui/editor/areas/isoGrid/IsoGridEditorContent.tsx
+++ b/src/ui/editor/areas/isoGrid/IsoGridEditorContent.tsx
@@ -4,7 +4,6 @@ import * as THREE from 'three';
 import Renderer from '../../../../renderer';
 import { fullscreen } from '../../../styles/index';
 import FrameListener from '../../../utils/FrameListener';
-import DebugData from '../../DebugData';
 import { TickerProps } from '../../../utils/Ticker';
 import { getIsometricCamera } from '../../../../cameras/iso';
 import { loadIsometricScenery } from '../../../../iso';
@@ -16,10 +15,9 @@ import {
     getSceneMap,
 } from '../../../../resources';
 import { WORLD_SCALE_B, WORLD_SIZE } from '../../../../utils/lba';
+import DebugData from '../../DebugData';
 
 interface Props extends TickerProps {
-    mainData: any;
-    saveMainData: Function;
     params: any;
     sharedState: {
         isoGridIdx: number;
@@ -102,7 +100,7 @@ export default class IsoGridEditorContent extends FrameListener<Props, State> {
 
         this.onLoad = this.onLoad.bind(this);
         this.frame = this.frame.bind(this);
-        this.saveData = this.saveData.bind(this);
+        this.saveDebugScope = this.saveDebugScope.bind(this);
         this.onKeyDown = this.onKeyDown.bind(this);
         this.onKeyUp = this.onKeyUp.bind(this);
         this.onMouseDown = this.onMouseDown.bind(this);
@@ -110,50 +108,40 @@ export default class IsoGridEditorContent extends FrameListener<Props, State> {
         this.onMouseMove = this.onMouseMove.bind(this);
         this.onWheel = this.onWheel.bind(this);
 
-        if (props.mainData) {
-            this.state = props.mainData.state;
-        } else {
-            const isoCamera = getIsometricCamera();
-            const iso3DCamera = getIso3DCamera();
-            const cameras = [isoCamera, iso3DCamera];
-            const camera = cameras[this.cam];
-            const scene = {
-                camera,
-                threeScene: new THREE.Scene(),
-                target: {
-                    threeObject: new THREE.Object3D()
-                }
-            };
-            const controlsState = {
-                cameraLerp: new THREE.Vector3(),
-                cameraLookAtLerp: new THREE.Vector3()
-            };
-            scene.threeScene.add(isoCamera.threeCamera);
-            scene.threeScene.add(iso3DCamera.controlNode);
-            const selectionObj = makeSelectionObject();
-            selectionObj.visible = false;
-            scene.threeScene.add(selectionObj);
-            const clock = new THREE.Clock(false);
-            this.state = {
-                scene,
-                clock,
-                controlsState,
-                selectionObj,
-                isoGridIdx: 0,
-                cameras
-            };
-            clock.start();
-        }
+        const isoCamera = getIsometricCamera();
+        const iso3DCamera = getIso3DCamera();
+        const cameras = [isoCamera, iso3DCamera];
+        const camera = cameras[this.cam];
+        const scene = {
+            camera,
+            threeScene: new THREE.Scene(),
+            target: {
+                threeObject: new THREE.Object3D()
+            }
+        };
+        const controlsState = {
+            cameraLerp: new THREE.Vector3(),
+            cameraLookAtLerp: new THREE.Vector3()
+        };
+        scene.threeScene.add(isoCamera.threeCamera);
+        scene.threeScene.add(iso3DCamera.controlNode);
+        const selectionObj = makeSelectionObject();
+        selectionObj.visible = false;
+        scene.threeScene.add(selectionObj);
+        const clock = new THREE.Clock(false);
+        this.state = {
+            scene,
+            clock,
+            controlsState,
+            selectionObj,
+            isoGridIdx: 0,
+            cameras
+        };
+        clock.start();
     }
 
-    saveData() {
-        if (this.props.saveMainData) {
-            DebugData.scope = this.state;
-            this.props.saveMainData({
-                state: this.state,
-                canvas: this.canvas
-            });
-        }
+    saveDebugScope() {
+        DebugData.scope = this.state;
     }
 
     async preload() {
@@ -162,24 +150,20 @@ export default class IsoGridEditorContent extends FrameListener<Props, State> {
     }
 
     async onLoad(root) {
-        await this.preload();
-        if (!this.root) {
-            if (this.props.mainData) {
-                this.canvas = this.props.mainData.canvas;
-            } else {
-                this.canvas = document.createElement('canvas');
-                this.canvas.tabIndex = 0;
-                const renderer = new Renderer(
-                    this.props.params,
-                    this.canvas,
-                    {},
-                    'iso_grids_editor'
-                );
-                renderer.threeRenderer.setAnimationLoop(() => {
-                    this.props.ticker.frame();
-                });
-                this.setState({ renderer }, this.saveData);
-            }
+        if (!this.root && root) {
+            await this.preload();
+            this.canvas = document.createElement('canvas');
+            this.canvas.tabIndex = 0;
+            const renderer = new Renderer(
+                this.props.params,
+                this.canvas,
+                {},
+                'iso_grids_editor'
+            );
+            renderer.threeRenderer.setAnimationLoop(() => {
+                this.props.ticker.frame();
+            });
+            this.setState({ renderer }, this.saveDebugScope);
             this.root = root;
             this.root.appendChild(this.canvas);
         }
@@ -290,10 +274,10 @@ export default class IsoGridEditorContent extends FrameListener<Props, State> {
                 (x + 0.5) / 32
             );
             this.state.selectionObj.position.multiplyScalar(WORLD_SIZE);
-            this.setState({ selectionData }, this.saveData);
+            this.setState({ selectionData }, this.saveDebugScope);
         } else {
             this.state.selectionObj.visible = false;
-            this.setState({ selectionData: null }, this.saveData);
+            this.setState({ selectionData: null }, this.saveDebugScope);
         }
     }
 
@@ -326,7 +310,7 @@ export default class IsoGridEditorContent extends FrameListener<Props, State> {
             this.state.scene.target.threeObject.updateWorldMatrix();
         }
         this.loading = false;
-        this.setState({isoGrid, isoGridIdx});
+        this.setState({isoGrid, isoGridIdx}, this.saveDebugScope);
         return isoGrid;
     }
 

--- a/src/ui/editor/areas/layouts/browser/LayoutsNode.tsx
+++ b/src/ui/editor/areas/layouts/browser/LayoutsNode.tsx
@@ -3,6 +3,7 @@ import { map, times } from 'lodash';
 import DebugData from '../../../DebugData';
 import Renderer from '../../../../../renderer';
 import { getBricks } from '../../../../../resources';
+import { areResourcesPreloaded } from '../../../../../resources/load';
 
 const indexStyle = {
     position: 'absolute' as const,
@@ -203,10 +204,12 @@ function getIcon(data, component) {
 }
 
 let bkg = null;
+let loading = false;
 const libraries = {};
 
 const getLayouts = () => {
-    if (!bkg) {
+    if (!bkg && areResourcesPreloaded() && !loading) {
+        loading = true;
         getBricks().then((lBkg) => {
             bkg = lBkg;
         });

--- a/www/layout.css
+++ b/www/layout.css
@@ -242,6 +242,19 @@ select:focus {
     outline:0;
 }
 
+canvas:focus {
+    outline:0;
+}
+
+*:focus {
+    outline: 2px solid rgb(114, 166, 200);
+}
+
+.editor_area:focus-within {
+    outline: 2px solid rgb(114, 166, 200);
+    z-index: 100;
+}
+
 *::-webkit-scrollbar-track
 {
     -webkit-box-shadow: inset 0 0 0px rgba(0,0,0,0.3);


### PR DESCRIPTION
Up until now, the react components for editor areas were rendered as a binary tree, with the consequence that when an area was added or removed somewhere, the tree structure would change, and react would lose track of which component is what.

That means, for example, that for the main view in the gameplay editor, the react component would be unmounted and remounted when closing a side panel, and thus the game, renderer, scene, etc would all be reloaded as a result. To prevent that from happening I was using a saveMainData() function, responsible for saving an restoring the state of components when they were recreated. At the cost of some unwanted extra complexity in those components.

An additional problem with rendering the editor areas as a binary tree is that each area is positioned relative to their parent, which means they can't easily be moved around, turned into a floating window, minimised, or swapped with other areas.

So, the goal of this PR is to give each area some global coordinates and display them as a flat list with a stable react key, so they don't get destroyed at all when moved around. This simplifies the areas component code, keeping the complexity within the Editor component. The data structure for storing areas is still a binary tree, only the rendering part is flattened.

I made some additional styling changes in the PR regarding HTML focus, I'm now indicating clearly which area is focused, in a clean way, as opposed to the confusing frames appearing (or not) before around focused html elements.

**Preview here:** https://pr-400.lba2remake.net