### PR TITLE
[Iso3D] Compile morph target animations

### DIFF
--- a/src/game/scenery/isometric/metadata/replacements.ts
+++ b/src/game/scenery/isometric/metadata/replacements.ts
@@ -166,17 +166,17 @@ async function addReplacementObject(info, replacements, gx, gy, gz) {
 
     const bindings = [];
     if (animations && animations.length) {
-        each(animations, (animationBase) => {
+        for (const animationBase of animations) {
             const animation = animationBase.clone(true);
             const {tracks} = animation;
-            each(tracks, (track) => {
+            for (const track of tracks) {
                 bindings.push({
                     track,
                     binding: new THREE.PropertyBinding(threeObject, track.name)
                 });
-            });
+            }
             replacements.animations.push(animation);
-        });
+        }
     }
 
     const skip = new Set();
@@ -195,7 +195,7 @@ async function addReplacementObject(info, replacements, gx, gy, gz) {
     threeObject.traverse((node) => {
         node.updateMatrix();
         node.updateMatrixWorld(true);
-        each(bindings, ({binding, track}) => {
+        for (const {binding, track} of bindings) {
             if (binding.node === node) {
                 if (node.parent !== threeObject) {
                     // tslint:disable-next-line: no-console
@@ -221,9 +221,8 @@ async function addReplacementObject(info, replacements, gx, gy, gz) {
                         geometries: makeReplacementGeometries(replacements.data)
                     }
                 });
-                return;
             }
-        });
+            }
         if (skip.has(node.parent)) {
             skip.add(node);
             if (node instanceof THREE.Mesh) {
@@ -238,12 +237,12 @@ async function addReplacementObject(info, replacements, gx, gy, gz) {
             appendMeshGeometry(replacements, gTransform, node, info, angle);
         }
     });
-    each(animNodes, ({group, data}) => {
+    for (const {group, data} of animNodes) {
         buildReplacementMeshes({
             geometries: data.geometries,
             threeObject: group
         });
-    });
+    }
     if (animRoot.children.length > 0) {
         replacements.threeObject.add(animRoot);
     }

--- a/src/ui/editor/areas/layouts/LayoutsEditorContent.tsx
+++ b/src/ui/editor/areas/layouts/LayoutsEditorContent.tsx
@@ -655,13 +655,13 @@ export default class LayoutsEditorContent extends FrameListener<Props, State> {
         }
         const { library } = this.props.sharedState;
         const scenes = await findScenesUsingLibrary(library);
+        const sceneMap = await getSceneMap();
         for (let i = 0; i < scenes.length; i += 1) {
             const scene = scenes[i];
             this.setState({
                 updateProgress: `Updating scene ${i + 1} / ${scenes.length}`
             }, this.saveDebugScope);
             const sceneData = await getScene(scene);
-            const sceneMap = await getSceneMap();
             await saveSceneReplacementModel(sceneMap[scene].sceneryIndex, sceneData.ambience);
         }
         this.setState({ updateProgress: null }, this.saveDebugScope);
@@ -972,7 +972,7 @@ function getLightVector() {
     return lightVector;
 }
 
-async function findScenesUsingLibrary(library) {
+async function findScenesUsingLibrary(library): Promise<number[]> {
     const bkg = await getBricksHQR();
     const sceneMap = await getSceneMap();
     const scenes = [];


### PR DESCRIPTION
This PR makes sure meshes with morphTarget-based animations are properly applied when compiling the scenes, so that the animation is visible in the target scene. Those are handled differently from transform-based animations.
Maybe factoring both types and simplifying the code there is possible, but I haven't figured how to do it yet. Will probably do this in a future PR.

**Preview here:** https://pr-453.lba2remake.net