### PR TITLE
fix import script folder creation

### DIFF
--- a/src/utils/fsutils.ts
+++ b/src/utils/fsutils.ts
@@ -5,7 +5,7 @@ import { exec } from 'child_process';
 
 export const createFolderIfNotExists = (folderPath: string) => {
     if (!fs.existsSync(folderPath)) {
-        fs.mkdirSync(folderPath);
+        fs.mkdirSync(folderPath, { recursive: true });
     }
 };
 


### PR DESCRIPTION
Running the data import on fresh copy fails as the www/data folder doesn't exist.
Enabling recursive folder creation will ensure that the folders are created correctly.

**Preview here:** https://pr-476.lba2remake.net