### PR TITLE
Fixed meca pinguim checks for both LBA1 and LBA2

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -201,8 +201,12 @@ export default class Actor {
         this.physics = initPhysics(props);
         this.state = Actor.createState();
         this.state.isVisible = props.flags.isVisible
-            && (props.life > 0 || props.bodyIndex >= 0)
-            && props.index !== 1; // 1 is always Nitro-mecapingouin
+            && (props.life > 0 || props.bodyIndex >= 0);
+        // Do Meca Pinguin checks for both games correctly
+        if (getParams().game === 'lba2' && props.index === 1 ||
+            getParams().game === 'lba1' && props.entityIndex === 9) {
+            this.state.isVisible = false;
+        }
         this.scripts = {
             life: parseScript(props.index, 'life', props.lifeScript),
             move: parseScript(props.index, 'move', props.moveScript)

--- a/src/ui/editor/DebugData.ts
+++ b/src/ui/editor/DebugData.ts
@@ -144,7 +144,7 @@ export function getObjectName(type, sceneIndex, objIndex) {
         if (objIndex === 0) {
             return 'Twinsen';
         }
-        if (objIndex === 1) {
+        if (getParams().game === 'lba2' && objIndex === 1) {
             return 'MecaPinguin';
         }
     }


### PR DESCRIPTION
For LBA2 the meca pinguim was always Actor 1, but this is not true for LBA1, where meca pinguim is the very last actor.
This will fix some actors been hidden by mistake in LBA1 (like the Truck Outside the Citadel Island)