### PR TITLE
Fix iso collision a bit and implement fireball sound effect

### DIFF
--- a/src/game/MagicBall.ts
+++ b/src/game/MagicBall.ts
@@ -126,7 +126,11 @@ export default class MagicBall {
     }
 
     throw(angle, behaviour) {
-        this.scene.actors[0].playSample(SampleType.MAGIC_BALL_THROW);
+        if (this.game.getState().hero.magicball.level < 4) {
+            this.scene.actors[0].playSample(SampleType.MAGIC_BALL_THROW);
+        } else {
+            this.scene.actors[0].playSample(SampleType.FIRE_BALL_THROW);
+        }
 
         let direction = new THREE.Vector3(0, 0.1, 1.1);
         switch (behaviour) {

--- a/src/game/data/sampleType.ts
+++ b/src/game/data/sampleType.ts
@@ -1,6 +1,7 @@
 
 export const SampleType = {
     MAGIC_BALL_THROW: 0,
+    FIRE_BALL_THROW: 1,
     BONUS_COLLECTED: 2,
     BONUS_FOUND: 3,
     OBJECT_FOUND: 6,

--- a/src/game/scenery/isometric/IsoSceneryPhysics.ts
+++ b/src/game/scenery/isometric/IsoSceneryPhysics.ts
@@ -230,7 +230,6 @@ function getColumnY(column, position: THREE.Vector3) {
 
 const POSITION = new THREE.Vector3();
 const ACTOR_BOX = new THREE.Box3();
-const ACTOR_BOX_TEMP = new THREE.Box3();
 const INTERSECTION = new THREE.Box3();
 const ITRS_SIZE = new THREE.Vector3();
 const CENTER1 = new THREE.Vector3();
@@ -302,8 +301,6 @@ function processBoxIntersections(
     ACTOR_BOX.min.multiplyScalar(STEP);
     ACTOR_BOX.max.multiplyScalar(STEP);
     ACTOR_BOX.translate(position);
-    ACTOR_BOX_TEMP.copy(ACTOR_BOX);
-    DIFF.set(0, 1 / 128, 0);
 
     let collision = false;
     for (let ox = -1; ox < 2; ox += 1) {
@@ -315,13 +312,6 @@ function processBoxIntersections(
                     BB.copy(column.box);
                     if (column.shape !== 1) {
                         BB.max.y -= STEP;
-                    }
-
-                    // Reset and only apply the Y offset if it's a "floor" box.
-                    // This fixes Ralph getting stuck running out of the Trulu cave.
-                    ACTOR_BOX.copy(ACTOR_BOX_TEMP);
-                    if (BB.min.y < ACTOR_BOX.min.y) {
-                        ACTOR_BOX.translate(DIFF);
                     }
 
                     if (intersectBox(actor, position)) {
@@ -347,6 +337,11 @@ function intersectBox(actor: Actor, position: THREE.Vector3) {
         INTERSECTION.copy(ACTOR_BOX);
         INTERSECTION.intersect(BB);
         INTERSECTION.getSize(ITRS_SIZE);
+
+        if (ITRS_SIZE.y <= 1 / 128) {
+            return false;
+        }
+
         ACTOR_BOX.getCenter(CENTER1);
         BB.getCenter(CENTER2);
         const dir = CENTER1.sub(CENTER2);

--- a/src/game/scenery/isometric/IsoSceneryPhysics.ts
+++ b/src/game/scenery/isometric/IsoSceneryPhysics.ts
@@ -301,6 +301,7 @@ function processBoxIntersections(
     ACTOR_BOX.min.multiplyScalar(STEP);
     ACTOR_BOX.max.multiplyScalar(STEP);
     ACTOR_BOX.translate(position);
+    ACTOR_BOX.min.y += 1 / 128;
 
     let collision = false;
     for (let ox = -1; ox < 2; ox += 1) {
@@ -337,11 +338,6 @@ function intersectBox(actor: Actor, position: THREE.Vector3) {
         INTERSECTION.copy(ACTOR_BOX);
         INTERSECTION.intersect(BB);
         INTERSECTION.getSize(ITRS_SIZE);
-
-        if (ITRS_SIZE.y <= 1 / 128) {
-            return false;
-        }
-
         ACTOR_BOX.getCenter(CENTER1);
         BB.getCenter(CENTER2);
         const dir = CENTER1.sub(CENTER2);


### PR DESCRIPTION
Fixes a few random things:

- Ralph now runs correctly out of the Trulu cave, the DIFF of 1/128 was making his bounding box just slightly too high and clipping the top of the door. Slightly hacky fix but seems to work ok.
- Implement using the correct sound effect for the fire magic ball.
- Slightly tighten up the spike collision detection to match original implementation.

**Preview here:** https://pr-495.lba2remake.net