### PR TITLE
Fix HIT script implementation.

### DIFF
--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -385,7 +385,7 @@ export function SUB_LIFE_POINT_OBJ(this: ScriptContext, actor, value) {
 }
 
 export function HIT(this: ScriptContext, actor, strength) {
-    actor.wasHitBy = this.actor.index;
+    actor.state.wasHitBy = this.actor.index;
     actor.props.life -= strength;
 }
 


### PR DESCRIPTION
This fixes the button in the museum not working and was likely broken when we did that migration to add Actor state in the state object.

**Preview here:** https://pr-505.lba2remake.net