### PR TITLE
Fix bodyIndex and entityIndex changing outside of the actor loop.

### DIFF
--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -61,7 +61,7 @@ function handleBodyChanges(game: Game, scene: Scene, hero: Actor) {
     const equippedItem = game.getState().hero.equippedItemId;
     if (equippedItem < 0) {
         // Corner case for when Twinsen hasn't yet picked up the magic ball.
-        if (game.getState().flags.quest[4]) {
+        if (game.getState().flags.quest[LBA2Items.TUNIC]) {
             hero.setBody(scene, BodyType.TWINSEN_TUNIC);
         } else {
             hero.setBody(scene, BodyType.TWINSEN_NO_TUNIC);

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -30,12 +30,14 @@ export const BehaviourMode = {
 };
 
 export function updateHero(game: Game, scene: Scene, hero: Actor, time: Time) {
-    if (hero.props.dirMode !== ActorDirMode.MANUAL)
-        return;
-
     const behaviour = game.getState().hero.behaviour;
     handleBehaviourChanges(scene, hero, behaviour);
     handleBodyChanges(game, scene, hero);
+
+    if (hero.props.dirMode !== ActorDirMode.MANUAL) {
+        return;
+    }
+
     if (game.controlsState.firstPerson) {
         processFirstPersonsMovement(game, scene, hero, time);
     } else {
@@ -51,8 +53,19 @@ export function updateHero(game: Game, scene: Scene, hero: Actor, time: Time) {
 }
 
 function handleBodyChanges(game: Game, scene: Scene, hero: Actor) {
+    if (hero.props.dirMode !== ActorDirMode.MANUAL) {
+        hero.setBody(scene, hero.props.bodyIndex);
+        return;
+    }
+
     const equippedItem = game.getState().hero.equippedItemId;
     if (equippedItem < 0) {
+        // Corner case for when Twinsen hasn't yet picked up the magic ball.
+        if (game.getState().flags.quest[4]) {
+            hero.setBody(scene, BodyType.TWINSEN_TUNIC);
+        } else {
+            hero.setBody(scene, BodyType.TWINSEN_NO_TUNIC);
+        }
         return;
     }
 

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -71,7 +71,7 @@ function handleBodyChanges(game: Game, scene: Scene, hero: Actor) {
 
     if (hero.props.bodyIndex !== LBA2WeaponToBodyMapping[equippedItem]) {
         let body = LBA2WeaponToBodyMapping[equippedItem];
-        if (body === BodyType.TWINSEN_TUNIC && !game.getState().flags.quest[4]) {
+        if (body === BodyType.TWINSEN_TUNIC && !game.getState().flags.quest[LBA2Items.TUNIC]) {
             body = BodyType.TWINSEN_NO_TUNIC;
         }
         hero.setBody(scene, body);


### PR DESCRIPTION
This fixes Twinsen losing his Tunic when he teleports to a new area without having picked up the magic ball as well as transitioning to Twinsen+Zoe upon exiting the Trulu cave.

**Preview here:** https://pr-511.lba2remake.net