### PR TITLE
Various bug fixes for lighthouse scripting scene.

### DIFF
--- a/src/game/Game.ts
+++ b/src/game/Game.ts
@@ -37,6 +37,7 @@ export default class Game {
     private _isLoading: boolean;
     private _audio: any;
     private _loopFunctions: LoopFunction[];
+    private _cinema: boolean;
     menuTexts: any;
     texts: any;
 
@@ -50,6 +51,7 @@ export default class Game {
         this._gameState = createGameState();
         this._isPaused = false;
         this._isLoading = false;
+        this._cinema = false;
         this._audio = createAudioManager(this._gameState);
         this._loopFunctions = [];
     }
@@ -168,6 +170,11 @@ export default class Game {
     }
 
     @pure()
+    isCinema() {
+        return this._cinema;
+    }
+
+    @pure()
     getState() {
         return this._gameState;
     }
@@ -247,6 +254,11 @@ export default class Game {
             newLoopFunctions.push(f);
         });
         this._loopFunctions = newLoopFunctions;
+    }
+
+    setCinema(mode: boolean) {
+        this.setUiState({ cinema: mode });
+        this._cinema = mode;
     }
 
     async registerResources() {

--- a/src/game/Scene.ts
+++ b/src/game/Scene.ts
@@ -329,7 +329,7 @@ export default class Scene {
     }
 
     private updateSideScenes(time: Time) {
-        if (this.sideScenes) {
+        if (!this.game.isCinema() && this.sideScenes) {
             for (const sideScene of this.sideScenes.values()) {
                 sideScene.firstFrame = this.firstFrame;
                 sideScene.update(time);

--- a/src/game/SceneManager.ts
+++ b/src/game/SceneManager.ts
@@ -44,7 +44,7 @@ export class SceneManager {
         if (this.scene)
             this.scene.isActive = false;
 
-        this.game.setUiState({ text: null, cinema: false });
+        this.game.setUiState({ text: null });
         this.game.controlsState.skipListener = null;
 
         const hash = window.location.hash;

--- a/src/game/scripting/data/lba2/points.ts
+++ b/src/game/scripting/data/lba2/points.ts
@@ -5,5 +5,13 @@ export const LBA2PointOffsets = {
     2: {
         // Let Twinsen exit the Trulu cave.
         13: [0, 0, 0.5],
-    }
+    },
+    49: {
+        // Ensure Twinsen+Zoe don't clip into the next scene when walking to the lighthouse.
+        15: [-0.5, 0, 0],
+    },
+    46: {
+        // Ensure Twinsen+Zoe can enter the lighthouse.
+        6: [0, 0, 0.5],
+    },
 };

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -555,12 +555,12 @@ export const BALLOON = unimplemented();
 export const NO_SHOCK = unimplemented();
 
 export function CINEMA_MODE(this: ScriptContext, mode) {
-    if (mode === 1) {
+    if (mode > 0) {
         this.actor.props.dirMode = ActorDirMode.NO_MOVE;
-        this.game.setUiState({ cinema: true });
+        this.game.setCinema(true);
     } else {
         this.actor.props.dirMode = ActorDirMode.MANUAL;
-        this.game.setUiState({ cinema: false });
+        this.game.setCinema(false);
     }
 }
 

--- a/src/ui/game/TeleportMenu.tsx
+++ b/src/ui/game/TeleportMenu.tsx
@@ -350,6 +350,7 @@ export default class TeleportMenu extends React.Component<TMProps, TMState> {
     renderNode(node, level) {
         const goto = (e, child) => {
             if (child.goto) {
+                this.props.game.setCinema(false);
                 child.goto(this.props.game, this.props.sceneManager);
                 this.props.exit(e);
             }


### PR DESCRIPTION
This does a few things:

- Only update side scenes if we're not in cinema mode.
- Make cinema mode persist scene changes (corner case that if you use the teleport menu we force it to false).
- For some weird reason some life scripts are setting the cinema mode to 46?? so I've made the check less strict to just see if it's greater than 0 rather than exactly 1 to set cinema mode to true.
- Had to modify a few point locations with the offset logic I just added to get things to work correctly. 

At this point the entire scene plays out all the way until the end but there's still some issue with flags not getting set at the end (maybe because my video file is 404ing) need to see what's going on there but we're much closer than I thought.

**Preview here:** https://pr-512.lba2remake.net