### PR TITLE
Check for island flags at loading time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ _Unreleased_
 
 #### Gameplay
 
-- Switch Inventory Objects
+- Select Inventory objects
 - Positional Audio
+- Adding LBA1 Support
 - Gamepad Support
     * Tested with Razer Kishi Controller on Android
     * Tested with Steelwhell Nimbus Controller on Mac
-- Tweaked rotation speed
-- Adding LBA1 Support
+- Camera zone transitions during Cinema mode
+- Throw Magicball and weapon selection
+- Various gameplay fixes - the game is more playable throughout the story
 
 #### UI
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/agrande/lba2remake.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/agrande/lba2remake/alerts/)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/agrande/lba2remake.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/agrande/lba2remake/context:javascript)
 
-A Little Big Adventure 2 / Twinsen's Odyssey reimplementation in JavaScript / Three.js / React
+A Little Big Adventure 2 / Twinsen's Odyssey reimplementation in Typescript / Three.js / React
 
 #### [Live demo](https://www.lba2remake.net) (or [Editor mode](https://www.lba2remake.net/#editor=true))
 

--- a/src/game/scenery/island/Island.ts
+++ b/src/game/scenery/island/Island.ts
@@ -36,10 +36,11 @@ interface IslandData {
     smokeTexture: THREE.Texture;
 }
 
-interface IslandOptions {
-    cache: 'regular' | 'editor' | 'preview';
+export interface IslandOptions {
+    cache: 'none' |'regular' | 'editor' | 'preview';
     preview: boolean;
     editor: boolean;
+    flags?: any[];
 }
 
 interface IslandComponent {
@@ -61,9 +62,10 @@ export default class Island {
             name = 'CITADEL';
         }
         return Island.loadWithCache(name, sceneData.ambience, {
-            cache: 'regular',
+            cache: 'none',
             preview: false,
-            editor: false
+            editor: false,
+            flags: game.getState().flags.quest,
         });
     }
 
@@ -71,7 +73,7 @@ export default class Island {
         return Island.loadWithCache(name, ambience, {
             cache: 'editor',
             preview: false,
-            editor: true
+            editor: true,
         });
     }
 
@@ -79,7 +81,7 @@ export default class Island {
         return Island.loadWithCache(name, ambience, {
             cache: 'preview',
             preview: true,
-            editor: false
+            editor: false,
         });
     }
 
@@ -88,12 +90,14 @@ export default class Island {
         ambience: any,
         options: IslandOptions
     ): Promise<Island> {
-        if (islandsCache[options.cache].has(name)) {
+        if (options.cache !== 'none' && islandsCache[options.cache].has(name)) {
             return islandsCache[options.cache].get(name);
         }
         const data = await Island.loadData(name, ambience);
         const island = new Island(data, options);
-        islandsCache[options.cache].set(name, island);
+        if (options.cache !== 'none') {
+            islandsCache[options.cache].set(name, island);
+        }
         return island;
     }
 
@@ -124,7 +128,7 @@ export default class Island {
         this.threeObject = new THREE.Object3D();
         this.threeObject.name = `island_${data.name}`;
         this.threeObject.matrixAutoUpdate = false;
-        const layout = new IslandLayout(data.ile);
+        const layout = new IslandLayout(data.ile, options);
 
         const geomInfo = loadGeometries(this.threeObject, this.props, data, layout);
 

--- a/src/game/scenery/island/IslandLayout.ts
+++ b/src/game/scenery/island/IslandLayout.ts
@@ -1,4 +1,5 @@
 import { WORLD_SCALE, WORLD_SIZE } from '../../../utils/lba';
+import { IslandOptions } from './Island';
 
 export interface IslandObjectInfo {
     index: number;
@@ -9,6 +10,7 @@ export interface IslandObjectInfo {
     iv: number;
     soundType: number;
     boundingBox?: THREE.Box3;
+    flags: number;
 }
 
 export interface RawGroundMesh {
@@ -38,12 +40,12 @@ export default class IslandLayout {
     readonly groundSections: IslandSection[];
     readonly seaSections: SeaSection[];
 
-    constructor(ile) {
-        this.groundSections = this.loadGroundSections(ile);
+    constructor(ile, options: IslandOptions) {
+        this.groundSections = this.loadGroundSections(ile, options);
         this.seaSections = this.loadSeaSections();
     }
 
-    private loadGroundSections(ile): IslandSection[] {
+    private loadGroundSections(ile, options: IslandOptions): IslandSection[] {
         const layout_raw = new Uint8Array(ile.getEntry(0));
         const groundSections: IslandSection[] = [];
         let index = 0;
@@ -59,7 +61,11 @@ export default class IslandLayout {
                 const z = sZ - 8;
                 const objects: IslandObjectInfo[] = [];
                 for (let j = 0; j < numObjects; j += 1) {
-                    objects.push(this.loadObjectInfo(objectsDV, x, z, j));
+                    const obj = this.loadObjectInfo(objectsDV, x, z, j);
+                    if (options.flags && obj.flags && !options.flags[obj.flags]) {
+                        continue;
+                    }
+                    objects.push(obj);
                 }
                 groundSections.push({
                     id,
@@ -86,6 +92,7 @@ export default class IslandLayout {
         const oy = objectsDV.getInt32(offset + 8, true);
         const oz = objectsDV.getInt32(offset + 4, true);
         const angle = objectsDV.getUint8(offset + 21) >> 2;
+        const flags = objectsDV.getUint8(offset + 22);
         const soundType = objectsDV.getInt16(offset + 16, true);
         return {
             index: objectsDV.getUint32(offset, true),
@@ -95,6 +102,7 @@ export default class IslandLayout {
             angle,
             iv: 1,
             soundType,
+            flags,
         };
     }
 

--- a/src/game/scenery/island/IslandLayout.ts
+++ b/src/game/scenery/island/IslandLayout.ts
@@ -11,6 +11,7 @@ export interface IslandObjectInfo {
     soundType: number;
     boundingBox?: THREE.Box3;
     flags: number;
+    flagValue: number;
 }
 
 export interface RawGroundMesh {
@@ -62,7 +63,7 @@ export default class IslandLayout {
                 const objects: IslandObjectInfo[] = [];
                 for (let j = 0; j < numObjects; j += 1) {
                     const obj = this.loadObjectInfo(objectsDV, x, z, j);
-                    if (options.flags && obj.flags && !options.flags[obj.flags]) {
+                    if (options.flags && obj.flags && options.flags[obj.flags] !== obj.flagValue) {
                         continue;
                     }
                     objects.push(obj);
@@ -93,6 +94,7 @@ export default class IslandLayout {
         const oz = objectsDV.getInt32(offset + 4, true);
         const angle = objectsDV.getUint8(offset + 21) >> 2;
         const flags = objectsDV.getUint8(offset + 22);
+        const flagValue = objectsDV.getUint8(offset + 23);
         const soundType = objectsDV.getInt16(offset + 16, true);
         return {
             index: objectsDV.getUint32(offset, true),
@@ -103,6 +105,7 @@ export default class IslandLayout {
             iv: 1,
             soundType,
             flags,
+            flagValue,
         };
     }
 


### PR DESCRIPTION
Went for the easy route to avoid impacting the rendering performance.
For now the flags are checked at loading time only and Islands are not cached during gameplay. They are still cached for Editor and Preview Mode (VR)

**Preview here:** https://pr-523.lba2remake.net