### PR TITLE
Resources improvements

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -21,14 +21,6 @@ function createAudioContext() {
     return new AudioContext();
 }
 
-const biquadFilter = null;
-
-function setFilter(sound) {
-    const filter = (biquadFilter) ? biquadFilter : sound.context.createBiquadFilter();
-    filter.type = 'allpass';
-    sound.setFilter(filter);
-}
-
 export function createAudioManager(state) {
     const context = createAudioContext();
     const menuContext = createAudioContext();
@@ -93,18 +85,24 @@ export function createAudioManager(state) {
             // sound.setRefDistance(20);
             // sound.setMaxDistance(10000);
             sound.setVolume(1);
-            setFilter(sound);
+            const filter = sound.context.createBiquadFilter();
+            filter.type = 'allpass';
+            sound.setFilter(filter);
             return sound;
         },
         createSamplePositionalAudioDefault: (): THREE.PositionalAudio => {
             const sound = new THREE.PositionalAudio(listener);
-            setFilter(sound);
+            const filter = sound.context.createBiquadFilter();
+            filter.type = 'allpass';
+            sound.setFilter(filter);
             return sound;
         },
         createSampleAudio: (): THREE.Audio => {
             const sound = new THREE.Audio(listener);
             sound.setVolume(1);
-            setFilter(sound);
+            const filter = sound.context.createBiquadFilter();
+            filter.type = 'allpass';
+            sound.setFilter(filter);
             return sound;
         },
 

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -21,6 +21,14 @@ function createAudioContext() {
     return new AudioContext();
 }
 
+const biquadFilter = null;
+
+function setFilter(sound) {
+    const filter = (biquadFilter) ? biquadFilter : sound.context.createBiquadFilter();
+    filter.type = 'allpass';
+    sound.setFilter(filter);
+}
+
 export function createAudioManager(state) {
     const context = createAudioContext();
     const menuContext = createAudioContext();
@@ -85,24 +93,18 @@ export function createAudioManager(state) {
             // sound.setRefDistance(20);
             // sound.setMaxDistance(10000);
             sound.setVolume(1);
-            const filter = sound.context.createBiquadFilter();
-            filter.type = 'allpass';
-            sound.setFilter(filter);
+            setFilter(sound);
             return sound;
         },
         createSamplePositionalAudioDefault: (): THREE.PositionalAudio => {
             const sound = new THREE.PositionalAudio(listener);
-            const filter = sound.context.createBiquadFilter();
-            filter.type = 'allpass';
-            sound.setFilter(filter);
+            setFilter(sound);
             return sound;
         },
         createSampleAudio: (): THREE.Audio => {
             const sound = new THREE.Audio(listener);
             sound.setVolume(1);
-            const filter = sound.context.createBiquadFilter();
-            filter.type = 'allpass';
-            sound.setFilter(filter);
+            setFilter(sound);
             return sound;
         },
 

--- a/src/game/SceneManager.ts
+++ b/src/game/SceneManager.ts
@@ -5,6 +5,14 @@ import Game from './Game';
 import * as DBG from '../ui/editor/DebugData';
 import Scene from './Scene';
 import Renderer from '../renderer';
+import {
+    releaseSamples,
+    releaseAnimations,
+    releaseModels,
+    releaseLibraries,
+    releaseGrids,
+    releaseScenes,
+} from '../resources';
 
 declare global {
     var ga: Function;
@@ -72,6 +80,7 @@ export class SceneManager {
         }
         this.game.loading(index);
         this.renderer.setClearColor(0x000000);
+        this.release();
         this.scene = await Scene.load(this.game, this.renderer, this, index);
         this.renderer.applySceneryProps(this.scene.scenery.props);
         this.scene.isActive = true;
@@ -88,5 +97,14 @@ export class SceneManager {
 
     unloadScene() {
         this.scene = null;
+    }
+
+    release() {
+        releaseSamples();
+        releaseAnimations();
+        releaseModels();
+        releaseLibraries();
+        releaseGrids();
+        releaseScenes();
     }
 }

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -5,6 +5,7 @@ import {
     getResourcePath,
     registerResources,
     getResource,
+    releaseResource,
 }  from './load';
 import { getLanguageConfig } from '../lang';
 import { getBodyIndex, getAnimIndex } from '../model/entity';
@@ -167,6 +168,30 @@ const getModelReplacements = async () => {
     return await loadResource(ResourceName.MODEL_REPLACEMENTS);
 };
 
+const releaseSamples = async () => {
+    return await releaseResource(ResourceName.SAMPLES);
+};
+
+const releaseAnimations = async () => {
+    return await releaseResource(ResourceName.ANIM);
+};
+
+const releaseModels = async () => {
+    return await releaseResource(ResourceName.BODY);
+};
+
+const releaseLibraries = async () => {
+    return await releaseResource(ResourceName.LIBRARIES);
+};
+
+const releaseGrids = async () => {
+    return await releaseResource(ResourceName.GRIDS);
+};
+
+const releaseScenes = async () => {
+    return await releaseResource(ResourceName.SCENE);
+};
+
 export {
     registerResources,
     preloadResources,
@@ -199,4 +224,11 @@ export {
     getVoices,
     getMusic,
     getModelReplacements,
+    // release assets
+    releaseSamples,
+    releaseAnimations,
+    releaseModels,
+    releaseLibraries,
+    releaseGrids,
+    releaseScenes,
 };

--- a/src/resources/load.ts
+++ b/src/resources/load.ts
@@ -152,7 +152,7 @@ const register = (
         entries: [],
         parse: null,
         parseSync: null,
-        parsedEntries: [],
+        parsedEntries: {},
     };
 
     // check if we have already a resource with same file
@@ -212,7 +212,6 @@ const register = (
     resource.getNextHiddenEntry = (index: number) => {
         return resource.hqr.getNextHiddenEntry(index);
     };
-
     resource.getEntryAsync = async (index: number) => {
         if (resource.ref) {
             return resource.ref.getEntryAsync(index);
@@ -323,6 +322,16 @@ const getResource = (id: string, index?: number, param?: any) => {
     return resource;
 };
 
+const releaseResource = (id: string) => {
+    const resource = Resources[id];
+    if (resource && resource.loaded && resource.parsedEntries) {
+        Object.keys(resource.parsedEntries).forEach((key) => {
+            delete resource.parsedEntries[key];
+        });
+        resource.parsedEntries = {};
+    }
+};
+
 const getResourcePath = (id: string) => {
     return Resources[id].path;
 };
@@ -369,4 +378,5 @@ export {
     getResource,
     getResourcePath,
     registerResources,
+    releaseResource,
 };


### PR DESCRIPTION
Allows to release resources that may not be required anymore.
We were keeping all parsed resources in memory throughout the entire game. So the more we play, the more memory we were using for the parsed entries.

I've added the following resources to be released when a scene is loaded (not side scene) - The rest of the resources seem to be more used in the entire game, so only a selective of them have been added for now:

- Samples
There are few recurrent samples like Twinsen sounds, but different scenes will have different samples, so no point of keeping them for all the gameplay - we may not even go back to that scene for a long time

- Models and Animations
These most of the time are scene related as well, so no point of keeping them all

- Libraries and Grids
We will gain more benefit of these as we advance in the game and we switch to 

**Preview here:** https://pr-540.lba2remake.net