### PR TITLE
Shading improvements

### DIFF
--- a/src/model/geometries.ts
+++ b/src/model/geometries.ts
@@ -8,7 +8,7 @@ import FRAG_TEXTURED from './shaders/textured.frag.glsl';
 
 import {loadPaletteTexture, loadSubTextureRGBA} from '../texture';
 import {compile} from '../utils/shaders';
-import { WORLD_SIZE } from '../utils/lba';
+import { WORLD_SIZE, PolygonType } from '../utils/lba';
 import Lightning from '../game/scenery/island/environment/Lightning';
 import { getParams } from '../params';
 
@@ -278,19 +278,20 @@ function loadFaceGeometry(geometries, body) {
         const uvGroup = getUVGroup(body, p);
         const baseGroup = p.hasTransparency ? 'textured_transparent' : 'textured';
         const group = uvGroup ? `${baseGroup}_${uvGroup.join(',')}` : baseGroup;
+        const faceNormal = getFaceNormal(body, p);
         const addVertex = (j) => {
             const vertexIndex = p.vertex[j];
             if (p.hasTransparency || p.hasTex) {
                 createSubgroupGeometry(geometries, group, baseGroup, uvGroup);
                 push.apply(geometries[group].positions, getPosition(body, vertexIndex));
-                push.apply(geometries[group].normals, getNormal(body, vertexIndex));
+                push.apply(geometries[group].normals, faceNormal || getNormal(body, vertexIndex));
                 push.apply(geometries[group].uvs, getUVs(body, p, j));
                 push.apply(geometries[group].uvGroups, getUVGroup(body, p));
                 push.apply(geometries[group].bones, getBone(body, vertexIndex));
                 geometries[group].colors.push(p.colour);
             } else {
                 push.apply(geometries.colored.positions, getPosition(body, vertexIndex));
-                push.apply(geometries.colored.normals, getNormal(body, vertexIndex));
+                push.apply(geometries.colored.normals, faceNormal || getNormal(body, vertexIndex));
                 push.apply(geometries.colored.bones, getBone(body, vertexIndex));
                 geometries.colored.colors.push(p.colour);
             }
@@ -385,6 +386,26 @@ function getPosition(body, index) {
         vertex.y,
         vertex.z
     ];
+}
+
+const U = new THREE.Vector3();
+const V = new THREE.Vector3();
+const P1 = new THREE.Vector3();
+
+// Face normal algorithm from:
+// https://www.khronos.org/opengl/wiki/Calculating_a_Surface_Normal
+function getFaceNormal(body, poly) {
+    if (poly.polyType === PolygonType.FLAT) {
+        P1.fromArray(getPosition(body, poly.vertex[0]));
+        U.fromArray(getPosition(body, poly.vertex[1])).sub(P1);
+        V.fromArray(getPosition(body, poly.vertex[2])).sub(P1);
+        return [
+            (U.y * V.z) - (U.z * V.y),
+            (U.z * V.x) - (U.x * V.z),
+            (U.x * V.y) - (U.y * V.x),
+        ];
+    }
+    return null;
 }
 
 function getNormal(body, index) {

--- a/src/model/geometries.ts
+++ b/src/model/geometries.ts
@@ -31,6 +31,7 @@ interface ModelGeometry {
     colors: number[];
     normals: number[];
     bones: number[];
+    polyTypes: number[];
     linePositions: number[];
     lineNormals: number[];
     lineColors: number[];
@@ -49,6 +50,7 @@ function prepareGeometries(texture, bones, matrixRotation, palette, lutTexture, 
             normals: [],
             colors: [],
             bones: [],
+            polyTypes: [],
             linePositions: [],
             lineNormals: [],
             lineColors: [],
@@ -76,6 +78,7 @@ function prepareGeometries(texture, bones, matrixRotation, palette, lutTexture, 
             uvGroups: [],
             colors: [],
             bones: [],
+            polyTypes: [],
             linePositions: [],
             lineNormals: [],
             lineColors: [],
@@ -104,6 +107,7 @@ function prepareGeometries(texture, bones, matrixRotation, palette, lutTexture, 
             uvGroups: [],
             colors: [],
             bones: [],
+            polyTypes: [],
             linePositions: [],
             lineNormals: [],
             lineColors: [],
@@ -160,6 +164,7 @@ export function loadMesh(
             uvGroups,
             colors,
             normals,
+            polyTypes,
             bones: boneIndices,
             linePositions,
             lineNormals,
@@ -196,6 +201,10 @@ export function loadMesh(
             bufferGeometry.setAttribute(
                 'boneIndex',
                 new THREE.BufferAttribute(new Uint8Array(boneIndices), 1)
+            );
+            bufferGeometry.setAttribute(
+                'polyType',
+                new THREE.BufferAttribute(new Uint8Array(polyTypes), 1, false)
             );
 
             if (body.boundingBox) {
@@ -288,11 +297,13 @@ function loadFaceGeometry(geometries, body) {
                 push.apply(geometries[group].uvs, getUVs(body, p, j));
                 push.apply(geometries[group].uvGroups, getUVGroup(body, p));
                 push.apply(geometries[group].bones, getBone(body, vertexIndex));
+                geometries[group].polyTypes.push(p.polyType);
                 geometries[group].colors.push(p.colour);
             } else {
                 push.apply(geometries.colored.positions, getPosition(body, vertexIndex));
                 push.apply(geometries.colored.normals, faceNormal || getNormal(body, vertexIndex));
                 push.apply(geometries.colored.bones, getBone(body, vertexIndex));
+                geometries.colored.polyTypes.push(p.polyType);
                 geometries.colored.colors.push(p.colour);
             }
         };
@@ -322,6 +333,7 @@ function loadSphereGeometry(geometries, body) {
             push.apply(geometries.colored.normals, normal);
             push.apply(geometries.colored.bones, getBone(body, s.vertex));
             geometries.colored.colors.push(s.colour);
+            geometries.colored.polyTypes.push(0);
         };
 
         const { array: vertex } = sphereGeometry.attributes.position;
@@ -476,6 +488,7 @@ function createSubgroupGeometry(geometries, group, baseGroup, uvGroup) {
         uvGroups: [],
         colors: [],
         bones: [],
+        polyTypes: [],
         linePositions: [],
         lineNormals: [],
         lineColors: [],

--- a/src/model/shaders/colored.frag.glsl
+++ b/src/model/shaders/colored.frag.glsl
@@ -6,6 +6,7 @@ in vec3 vNormal;
 in float vColor;
 in vec3 vMVPos;
 in float vDistLightning;
+in float vPolyType;
 
 out vec4 fragColor;
 
@@ -15,8 +16,20 @@ out vec4 fragColor;
 #require "../../game/scenery/island/shaders/common/intensity.frag"
 
 void main() {
-    vec3 colWithDither = dither(vColor, intensity()).rgb;
-    vec3 colWithFog = fog(colWithDither);
+    vec3 color;
+    if (vPolyType < 0.5)
+    {
+        const vec2 halfPixV = vec2(0.0, 0.03125);
+        float colorIndex = floor(vColor / 16.0);
+        float intensity = mod(vColor, 16.0);
+        vec2 uv = vec2(intensity, colorIndex) * 0.0625 + halfPixV;
+        color = texture(palette, uv).rgb;
+    }
+    else
+    {
+        color = dither(floor(vColor / 16.0), intensity()).rgb;
+    }
+    vec3 colWithFog = fog(color);
     vec3 colWithLightning = lightning(colWithFog);
     fragColor = vec4(colWithLightning, 1.0);
 }

--- a/src/model/shaders/colored.vert.glsl
+++ b/src/model/shaders/colored.vert.glsl
@@ -12,12 +12,14 @@ in vec3 position;
 in vec3 normal;
 in float color;
 in float boneIndex;
+in float polyType;
 
 out vec3 vPosition;
 out vec3 vNormal;
 out float vColor;
 out vec3 vMVPos;
 out float vDistLightning;
+out float vPolyType;
 
 #require "../../game/scenery/island/shaders/common/lightning.vert"
 
@@ -35,4 +37,5 @@ void main() {
     vNormal = newNormal.xyz;
     vColor = color;
     vMVPos = mPos.xyz;
+    vPolyType = polyType;
 }

--- a/src/resources/parsers/body2.ts
+++ b/src/resources/parsers/body2.ts
@@ -166,7 +166,7 @@ function loadPolygon(data, offset, renderType, polyType, blockSize, bodyIndex) {
     poly.colour = data.getUint8(offset + 8, true);
 
     // dirty fix for Zoe's mustache
-    if (bodyIndex === 26 && poly.colour >= 16 && poly.colour < 32) {
+    if ((bodyIndex === 26 || bodyIndex === 17) && poly.colour >= 16 && poly.colour < 32) {
         poly.colour += 16;
     }
 

--- a/src/resources/parsers/body2.ts
+++ b/src/resources/parsers/body2.ts
@@ -103,6 +103,7 @@ function loadPolygons(object, bodyIndex) {
     );
     let offset = 0;
     while (offset < object.linesOffset - object.polygonsOffset) {
+        const polyType = data.getUint8(offset);
         const renderType = data.getUint16(offset, true);
         const numPolygons = data.getUint16(offset + 2, true);
         const sectionSize = data.getUint16(offset + 4, true);
@@ -115,14 +116,14 @@ function loadPolygons(object, bodyIndex) {
         const blockSize = ((sectionSize - 8) / numPolygons);
 
         for (let j = 0; j < numPolygons; j += 1) {
-            const poly = loadPolygon(data, offset, renderType, blockSize, bodyIndex);
+            const poly = loadPolygon(data, offset, renderType, polyType, blockSize, bodyIndex);
             object.polygons.push(poly);
             offset += blockSize;
         }
     }
 }
 
-function loadPolygon(data, offset, renderType, blockSize, bodyIndex) {
+function loadPolygon(data, offset, renderType, polyType, blockSize, bodyIndex) {
     const numVertex = (renderType & 0x8000) ? 4 : 3;
     const hasExtra = !!((renderType & 0x4000));
     const hasTex = !!((renderType & 0x8 && blockSize > 16));
@@ -130,6 +131,7 @@ function loadPolygon(data, offset, renderType, blockSize, bodyIndex) {
 
     const poly = {
         renderType,
+        polyType,
         vertex: [],
         colour: 0,
         intensity: 0,

--- a/src/resources/parsers/body2.ts
+++ b/src/resources/parsers/body2.ts
@@ -163,12 +163,11 @@ function loadPolygon(data, offset, renderType, polyType, blockSize, bodyIndex) {
     }
 
     // polygon color
-    const colour = data.getUint8(offset + 8, true);
-    poly.colour = Math.floor(colour / 16);
+    poly.colour = data.getUint8(offset + 8, true);
 
     // dirty fix for Zoe's mustache
-    if (bodyIndex === 26 && poly.colour === 1) {
-        poly.colour = 2;
+    if (bodyIndex === 26 && poly.colour >= 16 && poly.colour < 32) {
+        poly.colour += 16;
     }
 
     // polygon color intensity
@@ -201,7 +200,7 @@ function loadLines(object) {
         const index = i * 4;
         object.lines.push({
             unk1: rawLines[index],
-            colour: Math.floor((rawLines[index + 1] & 0x00FF) / 16),
+            colour: rawLines[index + 1] & 0x00FF,
             vertex1: rawLines[index + 2],
             vertex2: rawLines[index + 3]
         });
@@ -215,7 +214,7 @@ function loadSpheres(object) {
         const index = i * 4;
         object.spheres.push({
             unk1: rawSpheres[index],
-            colour: Math.floor((rawSpheres[index + 1] & 0x00FF) / 16),
+            colour: rawSpheres[index + 1] & 0x00FF,
             vertex: rawSpheres[index + 2],
             size: rawSpheres[index + 3] * WORLD_SCALE
         });

--- a/src/resources/parsers/body2.ts
+++ b/src/resources/parsers/body2.ts
@@ -126,7 +126,7 @@ function loadPolygons(object, bodyIndex) {
 function loadPolygon(data, offset, renderType, polyType, blockSize, bodyIndex) {
     const numVertex = (renderType & 0x8000) ? 4 : 3;
     const hasExtra = !!((renderType & 0x4000));
-    const hasTex = !!((renderType & 0x8 && blockSize > 16));
+    const hasTex = polyType > 7 && blockSize > 16;
     const hasTransparency = (renderType === 2);
 
     const poly = {

--- a/src/utils/lba.ts
+++ b/src/utils/lba.ts
@@ -26,6 +26,35 @@ const getAngleValues = () => {
     return { midValue, maxValue };
 };
 
+export const PolygonType = {
+    SOLID: 0,
+    FLAT: 1,
+    TRANS: 2,
+    TRAME: 3,
+    GOURAUD: 4,
+    DITHER: 5,
+    GOURAUD_TABLE: 6,
+    DITHER_TABLE: 7,
+    TEXTURE: 8,
+    TEXTURE_FLAT: 9,
+    TEXTURE_GOURAUD: 10,
+    TEXTURE_DITHER: 11,
+    TEXTURE_INCRUST: 12,
+    TEXTURE_INCRUST_FLAT: 13,
+    TEXTURE_INCRUST_GOURAUD: 14,
+    TEXTURE_INCRUST_DITHER: 15,
+    TEXTURE_Z: 16,
+    TEXTURE_Z_FLAT: 17,
+    TEXTURE_Z_GOURAUD: 18,
+    TEXTURE_Z_DITHER: 19,
+    TEXTURE_Z_INCRUST: 20,
+    TEXTURE_Z_INCRUST_FLAT: 21,
+    TEXTURE_Z_INCRUST_GOURAUD: 22,
+    TEXTURE_Z_INCRUST_DITHER: 23,
+    TEXTURE_Z_FOG: 24,
+    FLAG_ZBUFFER: 25,
+};
+
 export function getRotation(nextValue, currentValue, interpolation) {
     let angleDif = nextValue - currentValue;
     let computedAngle = 0;


### PR DESCRIPTION
Made some fixes on shading using the properly parsed polyType property:

- Solid shading is when we just need to use a plain palette color without it being affect by lighting conditions. Examples: character eyes, most of the spheres (Twinsen's hair, etc).
- Flat shading is when the normals being used are computed face normals instead of vertices normals (this means models look more edgy instead of the gouraud shading). Examples: cart and arrows in Temple of Bu.
- Textures test was wrong, any polyType > 7 has texture. Probably still need some improvements for some specific textured shader cases that we're not handling properly yet.

The polyType property along with the PolygonType enum will allow us to implement the other original shaders more easily (in a future PR).

**Preview here:** https://pr-541.lba2remake.net