### PR TITLE
Don't play additional samples when already playing one

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -15,6 +15,7 @@ declare global {
 
 const THEME_MENU = 'THEME_MENU';
 const samples = {};
+const samplesPerActor = {};
 
 function createAudioContext() {
     window.AudioContext = window.AudioContext || window.webkitAudioContext; // needed for Safari
@@ -204,11 +205,16 @@ export function createAudioManager(state) {
             index: number,
             frequency: number = 0x1000,
             loopCount: number = 0,
+            actorIndex: number = -1,
             volume: number = state.config.soundFxVolume
         ) => {
             const sampleSource = createSampleSource(context, volume);
             sampleSource.play(index, frequency, loopCount);
             samples[index] = sampleSource;
+            if (!samplesPerActor[actorIndex]) {
+                samplesPerActor[actorIndex] = {};
+            }
+            samplesPerActor[actorIndex][index] = sampleSource;
             return sampleSource;
         },
         isPlayingSample: (index: number) => {
@@ -217,6 +223,15 @@ export function createAudioManager(state) {
                 return sampleSource.isPlaying();
             }
             return false;
+        },
+        isPlayingSampleForActor: (actorIndex: number, sampleIndex: number) => {
+            if (!samplesPerActor[actorIndex]) {
+                return false;
+            }
+            if (!samplesPerActor[actorIndex][sampleIndex]) {
+                return false;
+            }
+            return samplesPerActor[actorIndex][sampleIndex].isPlaying();
         },
         stopSample: (index: number) => {
             const sampleSource = samples[index];
@@ -231,6 +246,14 @@ export function createAudioManager(state) {
                     sampleSource.stop();
                 }
             });
+        },
+        stopSamplesForActor: (actorIndex: number) => {
+            if (!samplesPerActor[actorIndex])
+                return;
+
+            for (const sample in samplesPerActor[actorIndex]) {
+                samplesPerActor[actorIndex][sample].stop();
+            }
         },
 
         // shared

--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -676,7 +676,11 @@ export default class Actor {
             audio.playSound(this.sound, index, frequency, loopCount);
             return;
         }
-        audio.playSample(index, frequency, loopCount);
+        if (audio.isPlayingSampleForActor(this.index, index)) {
+            // Don't play the sample again if this actor is already playing it.
+            return;
+        }
+        audio.playSample(index, frequency, loopCount, this.index);
     }
 
     stopSample(index?: number) {
@@ -686,6 +690,10 @@ export default class Actor {
             return;
         }
         audio.stopSample(index);
+    }
+
+    stopSamples() {
+        this.game.getAudioManager().stopSamplesForActor(this.index);
     }
 
     setSampleVolume(volume: number) {

--- a/src/game/Scene.ts
+++ b/src/game/Scene.ts
@@ -403,8 +403,9 @@ export default class Scene {
                                 sample.ambience,
                                 sample.frequency,
                                 0,
+                                -1,
                                 Math.random()
-                                * (this.game.getState().config.ambienceVolume - 0.05) + 0.05
+                                * (this.game.getState().config.ambienceVolume - 0.05) + 0.05,
                             );
                         }
                         break;

--- a/src/game/SceneManager.ts
+++ b/src/game/SceneManager.ts
@@ -73,18 +73,19 @@ export class SceneManager {
             this.scene = sideScene;
             reviveActor(this.scene.actors[0], this.game); // Awake twinsen
             this.scene.isActive = true;
-            audio.stopMusicTheme();
+            audio.stopMusic();
             audio.playMusic(this.scene.props.ambience.musicIndex);
             initSceneDebugData();
             return this.scene;
         }
         this.game.loading(index);
         this.renderer.setClearColor(0x000000);
+        this.cleanUp();
         this.release();
         this.scene = await Scene.load(this.game, this.renderer, this, index);
         this.renderer.applySceneryProps(this.scene.scenery.props);
         this.scene.isActive = true;
-        audio.stopMusicTheme();
+        audio.stopMusic();
         audio.playMusic(this.scene.props.ambience.musicIndex);
         initSceneDebugData();
         this.scene.firstFrame = true;
@@ -97,6 +98,15 @@ export class SceneManager {
 
     unloadScene() {
         this.scene = null;
+    }
+
+    cleanUp() {
+        if (!this.scene)
+            return;
+
+        for (const actor of this.scene.actors) {
+            actor.stopSamples();
+        }
     }
 
     release() {

--- a/src/game/data/sampleType.ts
+++ b/src/game/data/sampleType.ts
@@ -4,6 +4,7 @@ export const SampleType = {
     FIRE_BALL_THROW: 1,
     BONUS_COLLECTED: 2,
     BONUS_FOUND: 3,
+    JETPACK: 5,
     OBJECT_FOUND: 6,
     MAGIC_BALL_BOUNCE: 7,
     MAGIC_BALL_STOP: 8,

--- a/src/game/loop/animAction.ts
+++ b/src/game/loop/animAction.ts
@@ -93,6 +93,10 @@ export const SAMPLE_RND = (action: AnimAction, { actor }: AnimActionContext) => 
     actor.playSample(action.sampleIndex, frequency);
 };
 
+export const SAMPLE_REPEAT = (action: AnimAction, { actor }: AnimActionContext) => {
+    actor.playSample(action.sampleIndex, 0x1000, action.repeat);
+};
+
 export const THROW = (action: AnimAction, { actor, game, scene }: AnimActionContext) => {
     const destAngle = ((action.beta * 2 * Math.PI) / 0x1000)
         + actor.physics.temp.angle - (Math.PI / 2);
@@ -124,10 +128,6 @@ export const THROW_MAGIC = (_action: AnimAction, { actor, game, scene }: AnimAct
     MagicBall.load(game, scene, actor.physics.position).then((mb: MagicBall) => {
         mb.throw(actor.physics.temp.angle, actor.props.entityIndex);
     });
-};
-
-export const SAMPLE_REPEAT = (action: AnimAction, { actor }: AnimActionContext) => {
-    actor.playSample(action.sampleIndex, 0x1000, action.repeat);
 };
 
 export const THROW_SEARCH = unimplemented();

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import Actor, { ActorDirMode, ActorState } from '../Actor';
 import { AnimType } from '../data/animType';
+import { SampleType } from '../data/sampleType';
 import { LBA2BodyType, LBA1BodyType } from '../data/bodyType';
 import { LBA2WeaponToBodyMapping, LBA2Items, LBA1Items, LBA1WeaponToBodyMapping } from '../data/inventory';
 import { WORLD_SIZE } from '../../utils/lba';
@@ -191,6 +192,12 @@ function processFirstPersonsMovement(game: Game, scene: Scene, hero: Actor, time
             return;
         }
 
+        if (controlsState.controlVector.y === 0 &&
+            (hero.props.entityIndex === BehaviourMode.JETPACK ||
+             hero.props.entityIndex === BehaviourMode.PROTOPACK)) {
+            hero.stopSample(SampleType.JETPACK);
+        }
+
         if (hero.props.entityIndex === BehaviourMode.AGGRESSIVE) {
             firstPersonPunching(game, scene, time);
         }
@@ -369,6 +376,12 @@ function processActorMovement(
         }
         if (checkDrowningAnim(game, scene, hero, time)) {
             return;
+        }
+
+        if (controlsState.controlVector.y === 0 &&
+            (hero.props.entityIndex === BehaviourMode.JETPACK ||
+             hero.props.entityIndex === BehaviourMode.PROTOPACK)) {
+            hero.stopSample(SampleType.JETPACK);
         }
 
         animIndex = AnimType.NONE;


### PR DESCRIPTION
This changes to keep track of samples on a per actor basis i.e. we allow the same sample to be concurrently played but only once per actor. This allows two enemies to shoot at the same time with the same sample and we'll hear both, but in the case of the jetpack we don't play that sample twice since it's the same actor (Twinsen).

This doesn't change the 3D positional audio stuff, need to look at that some more. We also still aren't looping samples correctly (there's still a slight gap at the end of the jetpack sample playback, still trying to work out how best to resolve that.

I've also fixed the case where we end up with the theme music playing twice at the same time which has been annoying me for a while.

**Preview here:** https://pr-561.lba2remake.net