### PR TITLE
Fixup music playing to behave like the original game

### DIFF
--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -5,12 +5,21 @@ const musicDecodedAudioCache = [];
 
 const createMusicSource = (context: any, volume: number = 1) => {
     const source = createSource(context, volume);
-    const loadPlay = async (index: number | string) => {
+    let playingIndex = -1;
+    const loadPlay = async (index: number | string, callback = null) => {
         if (!source.volume) {
             return;
         }
+        const wrappedCallback = () => {
+            playingIndex = -1;
+            source.isPlaying = false;
+            if (callback) {
+                callback();
+            }
+        };
         if (musicDecodedAudioCache[index]) {
             source.load(musicDecodedAudioCache[index]);
+            source.bufferSource.onended = wrappedCallback;
             source.play();
             return;
         }
@@ -23,6 +32,7 @@ const createMusicSource = (context: any, volume: number = 1) => {
             const buffer = await source.decode(entryBuffer.slice(0));
             musicDecodedAudioCache[index] = buffer;
             source.load(buffer);
+            source.bufferSource.onended = wrappedCallback;
             source.play();
         } catch (err) {
             // tslint:disable-next-line: no-console
@@ -33,10 +43,17 @@ const createMusicSource = (context: any, volume: number = 1) => {
         isPlaying: () => {
             return source.isPlaying;
         },
-        play: (index: number | string) => {
-            loadPlay(index);
+        play: (index: number | string, callback = null) => {
+            if (typeof(index) === 'number') {
+                playingIndex = index as number;
+            }
+            loadPlay(index, callback);
+        },
+        getPlaying(): number {
+            return playingIndex;
         },
         stop: () => {
+            playingIndex = -1;
             source.stop();
         },
         setVolume: (vol: number) => {

--- a/src/game/SceneManager.ts
+++ b/src/game/SceneManager.ts
@@ -73,8 +73,11 @@ export class SceneManager {
             this.scene = sideScene;
             reviveActor(this.scene.actors[0], this.game); // Awake twinsen
             this.scene.isActive = true;
-            audio.stopMusic();
-            audio.playMusic(this.scene.props.ambience.musicIndex);
+            if (audio.isPlayingMusic()) {
+                audio.queueMusic(this.scene.props.ambience.musicIndex);
+            } else {
+                audio.playMusic(this.scene.props.ambience.musicIndex);
+            }
             initSceneDebugData();
             return this.scene;
         }
@@ -85,8 +88,11 @@ export class SceneManager {
         this.scene = await Scene.load(this.game, this.renderer, this, index);
         this.renderer.applySceneryProps(this.scene.scenery.props);
         this.scene.isActive = true;
-        audio.stopMusic();
-        audio.playMusic(this.scene.props.ambience.musicIndex);
+        if (audio.isPlayingMusic()) {
+            audio.queueMusic(this.scene.props.ambience.musicIndex);
+        } else {
+            audio.playMusic(this.scene.props.ambience.musicIndex);
+        }
         initSceneDebugData();
         this.scene.firstFrame = true;
         if (getParams().editor) {


### PR DESCRIPTION
The mechanics of how the original game plays music are more complex than I realised:

- If you enter a new scene and no music is playing, play the music for that scene.
- If you enter a new scene and music is already playing, let it continue to play until finish, but queue up the current scene music and play that once the currently playing piece has finished.
- If you walk through multiple scenes only queue up the most recent scene music.
- If you walk out of a scene and back in again, don't queue up the same piece of music twice, or play the other scene piece.

Therefore I've added the ability to "queue" up music tracks. Think I've covered all the cases.

**Preview here:** https://pr-571.lba2remake.net