### PR TITLE
Don't block on dialogues in VR first person

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -261,7 +261,8 @@ export default class Actor {
 
         // Don't update the actor if someone else is talking.
         const currentTalkingActor = game.getState().actorTalking;
-        if (currentTalkingActor > -1 && currentTalkingActor !== this.index) {
+        if (currentTalkingActor > -1 && currentTalkingActor !== this.index &&
+            !(game.vr && game.controlsState.firstPerson)) {
             return;
         }
 

--- a/src/game/SceneManager.ts
+++ b/src/game/SceneManager.ts
@@ -83,6 +83,7 @@ export class SceneManager {
         }
         this.game.loading(index);
         this.renderer.setClearColor(0x000000);
+        this.game.getState().actorTalking = -1;
         this.cleanUp();
         this.release();
         this.scene = await Scene.load(this.game, this.renderer, this, index);
@@ -112,6 +113,7 @@ export class SceneManager {
 
         for (const actor of this.scene.actors) {
             actor.stopSamples();
+            actor.stopVoice();
         }
     }
 

--- a/src/game/loop/physics.ts
+++ b/src/game/loop/physics.ts
@@ -26,7 +26,8 @@ function processActorPhysics(game: Game, scene: Scene, actor: Actor, time: Time)
 
     // If someone is talking who isn't this actor, don't process the physics.
     const currentTalkingActor = game.getState().actorTalking;
-    if (currentTalkingActor > -1 && currentTalkingActor !== actor.index) {
+    if (currentTalkingActor > -1 && currentTalkingActor !== actor.index &&
+        !(game.vr && game.controlsState.firstPerson)) {
         return;
     }
     if (actor.state.isCarriedBy === -1) {

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -50,12 +50,13 @@ export function MESSAGE_OBJ(this: ScriptContext, cmdState, actor, id, sayMessage
         this.state.continue = false;
         return;
     }
+    const vrFirstPerson = this.game.vr && this.game.controlsState.firstPerson;
 
     const hero = this.scene.actors[0];
     const text = this.scene.props.texts[id];
     if (!cmdState.skipListener) {
         let onVoiceEndedCallback = null;
-        if (this.scene.vr) {
+        if (vrFirstPerson) {
             onVoiceEndedCallback = () => {
                 cmdState.ended = true;
             };
@@ -89,24 +90,24 @@ export function MESSAGE_OBJ(this: ScriptContext, cmdState, actor, id, sayMessage
                 }
             }, 4500);
         } else {
-            hero.props.dirMode = ActorDirMode.NO_MOVE;
-            hero.props.prevEntityIndex = hero.props.entityIndex;
-            hero.props.prevAnimIndex = hero.props.animIndex;
-            hero.props.entityIndex = 0;
-            this.game.getState().actorTalking = actor.index;
-            if (!isLBA1 && actor.index === 0)
-                hero.props.animIndex = AnimType.TALK;
-            else
-                hero.props.animIndex = AnimType.NONE;
-            if (!this.scene.vr) {
-                this.game.setUiState({
-                    text: {
-                        type: text.type === 3 ? 'big' : 'small',
-                        value: text.value,
-                        color: actor.props.textColor
-                    }
-                });
+            if (!vrFirstPerson) {
+                hero.props.dirMode = ActorDirMode.NO_MOVE;
+                hero.props.prevEntityIndex = hero.props.entityIndex;
+                hero.props.prevAnimIndex = hero.props.animIndex;
+                hero.props.entityIndex = 0;
+                if (!isLBA1 && actor.index === 0)
+                    hero.props.animIndex = AnimType.TALK;
+                else
+                    hero.props.animIndex = AnimType.NONE;
             }
+            this.game.setUiState({
+                text: {
+                    type: text.type === 3 ? 'big' : 'small',
+                    value: text.value,
+                    color: actor.props.textColor
+                }
+            });
+            this.game.getState().actorTalking = actor.index;
         }
 
         const that = this;
@@ -120,7 +121,7 @@ export function MESSAGE_OBJ(this: ScriptContext, cmdState, actor, id, sayMessage
                 });
             }
         };
-        if (text.type !== 9) {
+        if (text.type !== 9 && !vrFirstPerson) {
             this.game.controlsState.skipListener = cmdState.skipListener;
         }
     }


### PR DESCRIPTION
This allows to keep moving around in first person during dialogues. You can't skip dialogues anymore (not entirely sure about that one, but it feels more natural).
I think this probably needs more UX improvements but it should make VR more intuitive.

**Preview here:** https://pr-573.lba2remake.net