### PR TITLE
Fixes for SAME_XZ Control Mode

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -556,7 +556,6 @@ export default class Actor {
             this.threeObject.position.copy(this.physics.position);
             this.threeObject.quaternion.copy(this.physics.orientation);
             if (this.props.flags.isSprite) {
-                this.state.hasGravityByAnim = true;
                 const {spriteIndex, flags: { hasSpriteAnim3D } } = this.props;
                 const sprite = await loadSprite(
                     spriteIndex,

--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -291,23 +291,13 @@ export default class Actor {
 
         if (this.props.dirMode === ActorDirMode.SAME_XZ) {
             const { followActor } = this.props;
-            if (followActor && followActor !== -1) {
+            if (followActor > -1) {
                 const targetActor = scene.actors[followActor];
-                this.physics.position.copy(targetActor.physics.position);
-                if (this.model && targetActor.model) {
-                    this.model.mesh.quaternion.copy(targetActor.physics.orientation);
-                    this.model.mesh.position.copy(targetActor.physics.position);
-                    if (this.model.boundingBoxDebugMesh) {
-                        this.model.boundingBoxDebugMesh.quaternion.copy(
-                            targetActor.model.mesh.quaternion
-                        );
-                        this.model.boundingBoxDebugMesh.quaternion.invert();
-                    }
-                }
-                if (this.sprite) {
-                    this.sprite.threeObject.quaternion.copy(targetActor.physics.orientation);
-                    this.sprite.threeObject.position.copy(targetActor.physics.position);
-                }
+                const { x, z } = targetActor.physics.position;
+                const y = this.physics.position.y;
+                this.physics.position.set(x, y, z);
+                this.threeObject.quaternion.copy(targetActor.physics.orientation);
+                this.threeObject.position.copy(this.physics.position);
             }
         }
 

--- a/src/resources/parsers/scene1.ts
+++ b/src/resources/parsers/scene1.ts
@@ -169,7 +169,6 @@ function loadActors(scene, offset) {
 
         const staticFlags = data.getUint16(offset, true);
         actor.flags = parseStaticFlags(staticFlags);
-        actor.flags.hasCollisionFloor = true; // only used for LBA2
         offset += 2;
 
         actor.entityIndex = data.getInt16(offset, true);

--- a/src/resources/parsers/scene1.ts
+++ b/src/resources/parsers/scene1.ts
@@ -197,7 +197,7 @@ function loadActors(scene, offset) {
         offset += 2;
         actor.speed = data.getInt16(offset, true) * SPEED_ADJUSTMENT;
         offset += 2;
-        actor.dirMode = data.getInt16(offset);
+        actor.dirMode = data.getInt16(offset, true);
         offset += 2;
 
         actor.info0 = data.getInt16(offset, true);


### PR DESCRIPTION
Fixed SAME_XZ Control Mode implementation, setting correctly the three object and the actor position only on the XZ axis.
Also clean-up some collision variables that were set wrongly for Sprite Actors. (no side effects based on what I've tested)

This can be tested in LBA1 Prison. The Platform Hook uses SAME_XZ control mode to follow the Platform.

**Preview here:** https://pr-577.lba2remake.net