### PR TITLE
Fix for crash when loading a scene twice

### DIFF
--- a/src/game/scenery/isometric/metadata/models.ts
+++ b/src/game/scenery/isometric/metadata/models.ts
@@ -18,12 +18,7 @@ import { getParams } from '../../../../params';
 
 const exporter = new GLTFExporter();
 
-const modelsCache = {};
-
 export async function loadModel(file: string, useCache: boolean = false) : Promise<GLTF> {
-    if (useCache && file in modelsCache) {
-        return modelsCache[file];
-    }
     const model = await new Promise<GLTF>((resolve) => {
         const loader = new GLTFLoader();
         if (!useCache) {
@@ -33,9 +28,6 @@ export async function loadModel(file: string, useCache: boolean = false) : Promi
             resolve(m);
         });
     });
-    if (useCache) {
-        modelsCache[file] = model;
-    }
     return model;
 }
 


### PR DESCRIPTION
The crash was due to the cached version of the model being broken due to moving its content to another scene graph (a node can only have one parent).
I'm only caching at the HTTP level to fix this. Not optimal, but this will do for now.

**Preview here:** https://pr-582.lba2remake.net