### PR TITLE
Convert lighting values to LBA2 angles

### DIFF
--- a/src/resources/parsers/scene1.ts
+++ b/src/resources/parsers/scene1.ts
@@ -71,6 +71,10 @@ function loadAmbience(scene, offset) {
         musicIndex: data.getInt8(innerOffset + 32),
     };
 
+    // converting to LBA2 angle values
+    scene.ambience.lightingAlpha = (scene.ambience.lightingAlpha + 0x100) * 0x1000 / 0x400;
+    scene.ambience.lightingBeta = (scene.ambience.lightingBeta) * 0x1000 / 0x400;
+
     innerOffset = 4;
     for (let i = 0; i < 4; i += 1) {
         scene.ambience.samples.push({


### PR DESCRIPTION
The maximum angle size for LBA1 is 0x400 (1024) while for LBA2 is 0x1000 (4096).
We are basing all our lighting calculations with 0x1000 which does not work for LBA1.

To avoid changing everything that has 0x1000 value conversion, I have directly converted the LBA1 angle values to fix the LBA2 format.

This fixed the scene lightning, so 3d actors shading looks better and it improved the 3d model replacements.

**Preview here:** https://pr-583.lba2remake.net