### PR TITLE
Distance 2/3D and other fixes

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -4,7 +4,7 @@ import {cloneDeep} from 'lodash';
 import { loadModel, Model } from '../model';
 import { loadAnimState, resetAnimState, updateKeyframeInterpolation, updateKeyframe } from '../model/animState';
 import { AnimType } from './data/animType';
-import { angleToRad, angleTo, getDistanceLba, WORLD_SCALE } from '../utils/lba';
+import { angleToRad, angleTo, getDistanceLba, WORLD_SCALE, distance2D } from '../utils/lba';
 import {createBoundingBox} from '../utils/rendering';
 import { loadSprite } from './scenery/isometric/sprites';
 
@@ -496,8 +496,18 @@ export default class Actor {
     }
 
     @pure()
+    getDistance2D(pos: THREE.Vector3) {
+        return distance2D(this.physics.position, pos);
+    }
+
+    @pure()
     getDistanceLba(pos: THREE.Vector3) {
         return getDistanceLba(this.getDistance(pos));
+    }
+
+    @pure()
+    getDistanceLba2D(pos: THREE.Vector3) {
+        return getDistanceLba(this.getDistance2D(pos));
     }
 
     stop() {

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -506,9 +506,8 @@ function processActorMovement(
                         : AnimType.LEFT;
                     let dy = 0;
                     if (hero.animState.keyframeLength) {
-                        const rotationSpeed = hero.props.entityIndex === BehaviourMode.DISCRETE
-                            ? 65
-                            : 24;
+                        const rotationSpeed =
+                            (isLBA1 || hero.props.entityIndex === BehaviourMode.DISCRETE) ? 65 : 24;
                         const rotY = (hero.animState.rotation.y * rotationSpeed) / WORLD_SIZE;
                         dy = (rotY * time.delta * 1000) / hero.animState.keyframeLength;
                     }

--- a/src/game/scripting/condition.ts
+++ b/src/game/scripting/condition.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { WORLD_SIZE } from '../../utils/lba';
+import { WORLD_SIZE, getDistanceLba } from '../../utils/lba';
 import { ScriptContext } from './ScriptContext';
 import { LBA2GameFlags } from '../data/gameFlags';
 import Actor from '../Actor';
@@ -26,7 +26,10 @@ export function DISTANCE(this: ScriptContext, actor: Actor) {
     if (actor.state.isDead) {
         return Infinity;
     }
-    return this.actor.getDistanceLba(actor.physics.position);
+    if (getDistanceLba(this.actor.physics.position.y - actor.physics.position.y) > 1500) {
+        return Infinity;
+    }
+    return this.actor.getDistanceLba2D(actor.physics.position);
 }
 
 export function ZONE(this: ScriptContext) {
@@ -143,7 +146,13 @@ export function CHAPTER(this: ScriptContext) {
 }
 
 export function DISTANCE_3D(this: ScriptContext, actor: Actor) {
-    return DISTANCE.call(this, actor);
+    if (!this.scene.isActive && (actor.index === 0 || this.actor.index === 0)) {
+        return Infinity;
+    }
+    if (actor.state.isDead) {
+        return Infinity;
+    }
+    return this.actor.getDistanceLba(actor.physics.position);
 }
 
 export function MAGIC_LEVEL(this: ScriptContext) {

--- a/src/game/scripting/move.ts
+++ b/src/game/scripting/move.ts
@@ -75,7 +75,7 @@ export function GOTO_POINT_3D(this: ScriptContext, point: Point) {
         point.physics.position,
         this.time.delta * WORLD_SCALE * this.actor.props.speed
     );
-    if (distance > 0.001) {
+    if (distance > 0.01) {
         this.state.reentryOffset = this.state.offset;
         this.state.continue = false;
     } else {


### PR DESCRIPTION
* Fixed distance issues causing Magicball not to work due to Y position distance checking.
* Distance and Distance3d have now a different implementation that take Y axis consideration on 3D
* For 2d distance added a Y validation like the original, to ensure distances are kept within the same Brick floor level
* Changed speed rotation for Twinsen in LBA1 that was too slow due to its turning animation keyframe length
* Fixed GOTO_3D_POINT distance threshold

**Preview here:** https://pr-587.lba2remake.net