### PR TITLE
Zone Fixes

### DIFF
--- a/src/game/loop/zones.ts
+++ b/src/game/loop/zones.ts
@@ -60,15 +60,14 @@ export function processZones(game: Game, scene: Scene, time: Time) {
     const hero = scene.actors[0];
     const pos = hero.physics.position.clone();
     game.controlsState.camZone = null;
-    pos.y += 0.005;
     for (const zone of scene.zones) {
         if (zone.props.type === 2)
             continue;
 
         const box = zone.props.box;
-        if (pos.x > box.xMin && pos.x < box.xMax &&
-            pos.y > box.yMin && pos.y < box.yMax &&
-            pos.z > box.zMin && pos.z < box.zMax) {
+        if (pos.x >= box.xMin && pos.x < box.xMax &&
+            pos.y >= box.yMin && pos.y <= box.yMax &&
+            pos.z >= box.zMin && pos.z < box.zMax) {
             const zoneType = ZoneOpcode[zone.props.type];
             if (zoneType !== null && zoneType.handler !== null) {
                 if (zoneType.handler(game, scene, zone, hero, time))

--- a/src/game/scripting/common.ts
+++ b/src/game/scripting/common.ts
@@ -24,7 +24,7 @@ export function NO_BODY(this: ScriptContext) {
 
 export function POS_POINT(this: ScriptContext, point: Point) {
     this.actor.physics.position.copy(point.physics.position);
-    if (this.actor.model) {
-        this.actor.model.mesh.position.copy(point.physics.position);
+    if (this.actor.threeObject) {
+        this.actor.threeObject.position.copy(point.physics.position);
     }
 }

--- a/src/game/scripting/condition.ts
+++ b/src/game/scripting/condition.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { WORLD_SIZE, getDistanceLba } from '../../utils/lba';
+import { getDistanceLba } from '../../utils/lba';
 import { ScriptContext } from './ScriptContext';
 import { LBA2GameFlags } from '../data/gameFlags';
 import Actor from '../Actor';
@@ -38,21 +38,15 @@ export function ZONE(this: ScriptContext) {
 
 export function ZONE_OBJ(this: ScriptContext, actor: Actor) {
     const pos = actor.physics.position.clone();
-    let halfHeight = 0.005 * WORLD_SIZE;
-    if (actor.model && actor.model.boundingBox) {
-        const bb = actor.model.boundingBox;
-        halfHeight = (bb.max.y - bb.min.y) * 0.5;
-    }
-    pos.y += halfHeight;
     let match: Zone = null;
     for (const zone of this.scene.zones) {
         if (zone.props.type !== 2)
             continue;
 
         const box = zone.props.box;
-        if (pos.x >= box.xMin && pos.x <= box.xMax &&
+        if (pos.x >= box.xMin && pos.x < box.xMax &&
             pos.y >= box.yMin && pos.y <= box.yMax &&
-            pos.z >= box.zMin && pos.z <= box.zMax) {
+            pos.z >= box.zMin && pos.z < box.zMax) {
             if (match) {
                 const szZone = (box.xMax - box.xMin)
                     + (box.yMax - box.yMin)

--- a/src/resources/parsers/scene1.ts
+++ b/src/resources/parsers/scene1.ts
@@ -285,6 +285,11 @@ function loadZones(scene, offset) {
         zone.info3 = data.getInt16(offset + 10, true);
         offset += 12;
 
+        // set the ladder like on LBA2
+        if (zone.type === 6 && !zone.info1) {
+            zone.info1 = 1;
+        }
+
         // normalising position
         zone.pos = [
             zone.box.xMin + ((zone.box.xMax - zone.box.xMin) / 2),


### PR DESCRIPTION
* Fixed actors zone detection that were using BB half height position by mistake. Not all zones are guarantee to have the height of half of the BB of actors. This was more evident on LBA1 where zones are smaller than LBA2.
* Ladders on LBA2 have info prop set to one, so to maintain the same behaviour on LBA1, the info prop is been overridden during scene parsing.
* POS_POSITION command was wrongly setting the object position and was not working for sprite actors.

**Preview here:** https://pr-591.lba2remake.net