### PR TITLE
Distance Command

### DIFF
--- a/src/game/scripting/condition.ts
+++ b/src/game/scripting/condition.ts
@@ -26,7 +26,7 @@ export function DISTANCE(this: ScriptContext, actor: Actor) {
     if (actor.state.isDead) {
         return Infinity;
     }
-    if (getDistanceLba(this.actor.physics.position.y - actor.physics.position.y) > 1500) {
+    if (getDistanceLba(Math.abs(this.actor.physics.position.y - actor.physics.position.y)) > 1500) {
         return Infinity;
     }
     return this.actor.getDistanceLba2D(actor.physics.position);


### PR DESCRIPTION
Ensure Y distance is checked correctly no matter which actor is running the script command.
This will cap the Y distance value to prevent grid upper floors to be a valid 2d distance.

**Preview here:** https://pr-599.lba2remake.net