### PR TITLE
Fix for falling actors (drunkard in bar, museum ticket seller, ...)

### DIFF
--- a/src/game/loop/physics.ts
+++ b/src/game/loop/physics.ts
@@ -35,7 +35,10 @@ function processActorPhysics(game: Game, scene: Scene, actor: Actor, time: Time)
     }
     if (actor.props.flags.hasCollisions) {
         if (!actor.state.hasGravityByAnim &&
-            actor.props.flags.canFall && !actor.state.isClimbing &&
+            (actor.props.flags.hasCollisionBricks ||
+                actor.props.flags.hasCollisionFloor) &&
+            actor.props.flags.canFall &&
+            !actor.state.isClimbing &&
             !actor.state.isUsingProtoOrJetpack &&
             actor.props.dirMode !== ActorDirMode.WAGON) {
             // Max falling speed: 0.15m per frame


### PR DESCRIPTION
I did a search through all the actors in the game to see which ones have neither `hasCollisionBricks` (which should be called `hasCollisionScenery` btw) or `hasCollisionFloor` but still have `canFall = true`.
Those were all falling through the floor.

I don't think this change should break anything, but tell me if you see something suspicious.

```
Scene   Actor
3       4
15      2
32      4
48      56
48      57
54      9
64      3
81      3
88      6
97      5
128     64
134     11
135     9
136     2
188     3
188     4
188     5
210     2
```

**Preview here:** https://pr-603.lba2remake.net