### PR TITLE
Revert logic for anim ended callback

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -613,6 +613,10 @@ export default class Actor {
             return;
         }
         this.props.animIndex = index;
+        if (this.animState.onAnimEnd) {
+            this.animState.onAnimEnd();
+        }
+        this.animState.onAnimEnd = null;
     }
 
     setSprite(scene, index) {

--- a/src/model/anim/AnimState.ts
+++ b/src/model/anim/AnimState.ts
@@ -75,7 +75,7 @@ export default class AnimState {
             this.pose.setFromKeyFrames(this.kfs, this.currentTime);
         }
         this.pose.skeleton.updateHierarchy();
-        if (this._hasEnded && this.onAnimEnd) {
+        if (this._currentFrame === this.anim.numKeyframes - 1 && this.onAnimEnd) {
             this.onAnimEnd();
             this.onAnimEnd = null;
         }


### PR DESCRIPTION
It seems hasEnded doesn't actually trigger when the animation has completely played through once which is what I want to trigger the callback being fired. This reverts to the logic we have in the previous implementation and shouldn't break anything since _hasEnded remains untouched.

At the moment falling for example is broken in autopush, this fixes that.

**Preview here:** https://pr-615.lba2remake.net