### PR TITLE
Lba1 fixes

### DIFF
--- a/src/cameras/vr/vrFirstPerson.ts
+++ b/src/cameras/vr/vrFirstPerson.ts
@@ -1,8 +1,11 @@
 import * as THREE from 'three';
 import { WORLD_SIZE } from '../../utils/lba';
 import sharedData from './sharedData';
+import { getParams } from '../../params';
 
-const HERO_TARGET_POS = new THREE.Vector3(0, 1.43, 0);
+const isLBA1 = getParams().game === 'lba1';
+
+const HERO_TARGET_POS = new THREE.Vector3(0, isLBA1 ? 1.30 : 1.43, 0);
 
 export function getVrFirstPersonCamera(renderer) {
     const camera = new THREE.PerspectiveCamera(

--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -93,11 +93,13 @@ function createQuestFlags() {
     }
 
     // set default values
-    quest[63] = 1;
-    quest[135] = 1;
-    quest[150] = 1;
-    quest[152] = 1; // rain
-    quest[159] = 256;
+    if (getParams().game === 'lba2') {
+        quest[63] = 1;
+        quest[135] = 1;
+        quest[150] = 1;
+        quest[152] = 1; // rain
+        quest[159] = 256;
+    }
 
     return quest;
 }

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -95,12 +95,12 @@ export function MESSAGE_OBJ(
                 }
             }, 4500);
         } else {
-            if (!vrFirstPerson) {
+            if (!vrFirstPerson && actor.index === 0) {
                 hero.props.dirMode = ActorDirMode.NO_MOVE;
                 hero.props.prevEntityIndex = hero.props.entityIndex;
                 hero.props.prevAnimIndex = hero.props.animIndex;
                 hero.props.entityIndex = 0;
-                if (!isLBA1 && actor.index === 0)
+                if (!isLBA1)
                     hero.props.animIndex = AnimType.TALK;
                 else
                     hero.props.animIndex = AnimType.NONE;
@@ -137,7 +137,9 @@ export function MESSAGE_OBJ(
         if (text.type !== 9) {
             this.game.setUiState({ text: null, skip: false, });
             this.game.controlsState.skipListener = null;
-            hero.props.dirMode = ActorDirMode.MANUAL;
+            if (actor.index === 0) {
+                hero.props.dirMode = ActorDirMode.MANUAL;
+            }
         }
         delete cmdState.skipListener;
         delete cmdState.ended;

--- a/src/resources/parsers/body1.ts
+++ b/src/resources/parsers/body1.ts
@@ -8,12 +8,12 @@ export const parseModelLBA1 = (resource, index, bodyProps) => {
     const bodyFlag = data.getInt16(0x00, true);
     const obj = {
         bodyFlag,
-        xMin: data.getInt16(0x02, true),
-        xMax: data.getInt16(0x04, true),
+        xMin: data.getInt16(0x02, true) / 1.5,
+        xMax: data.getInt16(0x04, true) / 1.5,
         yMin: data.getInt16(0x06, true),
         yMax: data.getInt16(0x08, true),
-        zMin: data.getInt16(0x0A, true),
-        zMax: data.getInt16(0x0C, true),
+        zMin: data.getInt16(0x0A, true) / 1.5,
+        zMax: data.getInt16(0x0C, true) / 1.5,
         version: bodyFlag & 0xff,
         hasAnimation: bodyFlag & (1 << 8),
         noSort: bodyFlag & (1 << 9),


### PR DESCRIPTION
Lba1 fixes:
* Remove default lba2 game flags
* While other actors were talking, twinsen animation was reseted, causing scripts to detect the animation change.
* Reducing the LBA1 models bounding boxes, which unblocks loads of collision issues with BB that are not squared.
* Adjusted VR camera height for Twinsen on LBA1

**Preview here:** https://pr-617.lba2remake.net