### PR TITLE
Bugfix: Duplicated Twinsen

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -649,13 +649,25 @@ export default class Actor {
         this.animState.onAnimEnd = callback;
     }
 
-    reloadModel(scene: Scene) {
+    private reloadCalls = 0;
+
+    async reloadModel(scene: Scene) {
+        this.reloadCalls += 1;
+        if (this.reloadCalls > 1) {
+            return;
+        }
+        while (this.reloadCalls > 0) {
+            await this.doReloadModel(scene);
+            this.reloadCalls -= 1;
+        }
+    }
+
+    private async doReloadModel(scene: Scene) {
         const oldObject = this.threeObject;
-        this.loadMesh().then(() => {
-            scene.addMesh(this.threeObject);
-            scene.removeMesh(oldObject);
-            this.threeObject.updateMatrixWorld();
-        });
+        await this.loadMesh();
+        scene.removeMesh(oldObject);
+        scene.addMesh(this.threeObject);
+        this.threeObject.updateMatrixWorld();
     }
 
     hit(hitBy, hitStrength) {

--- a/src/game/Scene.ts
+++ b/src/game/Scene.ts
@@ -26,6 +26,7 @@ import { Time } from '../datatypes';
 import { processPhysicsFrame } from './loop/physics';
 import { SpriteType } from './data/spriteType';
 import { LBA2PointOffsets } from './scripting/data/lba2/points';
+import { getBodyFromGameState } from './loop/hero';
 
 export interface SceneProps {
     index: number;
@@ -100,7 +101,7 @@ export default class Scene {
             scenery,
             parent
         );
-        await scene.loadObjects();
+        await scene.loadObjects(game);
 
         // Little keys are scene relative.
         game.getState().hero.keys = 0;
@@ -167,13 +168,25 @@ export default class Scene {
         this.initSceneNode();
     }
 
-    async loadObjects() {
+    async loadObjects(game: Game) {
+        function mapHeroProps(actor: ActorProps) {
+            if (actor.index !== 0) {
+                return actor;
+            }
+
+            return {
+                ...actor,
+                entityIndex: game.getState().hero.behaviour,
+                bodyIndex: getBodyFromGameState(game)
+            };
+        }
+
         const actors = await Promise.all<Actor>(
             this.props.actors.map(
                 actor => Actor.load(
                     this.game,
                     this,
-                    actor
+                    mapHeroProps(actor)
                 )
             )
         );


### PR DESCRIPTION
This fixes the issue where Twinsen's model appears twice in some scenes when moving through several scenes with the tunic.
This also makes sure the tunic (or other model variants) are directly loaded at scene load time, instead of after a call to reloadModel() on the first frame.

**Preview here:** https://pr-620.lba2remake.net