### PR TITLE
Improve Citadel Island metadata

### DIFF
--- a/www/metadata/lba2/game.json
+++ b/www/metadata/lba2/game.json
@@ -209,7 +209,10 @@
         "2": "removed_from_holomap"
       }
     },
-    null,
+    {
+      "name": "baggage_claim_downstairs_door_opened",
+      "type": "boolean"
+    },
     null,
     {
       "name": "lighthouse_keeper",
@@ -226,7 +229,17 @@
       "name": "tralus_cave_gate_opened",
       "type": "boolean"
     },
-    null,
+    {
+      "name": "sewer_secret_room_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "nothing",
+        "1": "examined_map",
+        "2": "map_revealed",
+        "3": "found_pyramid_shaped_key",
+        "4": "opened_room"
+      }
+    },
     null,
     {
       "name": "clearing_up_the_rain",
@@ -240,9 +253,30 @@
         "5": "achieved"
       }
     },
+    {
+      "name": "dinofly_healer_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "nothing",
+        "1": "umbrella_stolen",
+        "2": "got_umbrella",
+        "3": "go_see_desert_island_healing_wizard"
+      }
+    },
     null,
-    null,
-    null,
+    {
+      "name": "twinsun_ferry_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "nothing",
+        "1": "ticket_to_desert_island",
+        "3": "going_to_desert_island",
+        "4": "arrived_desert_island",
+        "5": "ticket_to_citadel_island",
+        "7": "going_to_citadel_island",
+        "8": "arrived_citadel_island"
+      }
+    },
     {
       "name": "freeing_raph_status",
       "type": "enum",
@@ -253,27 +287,106 @@
         "3": "freed_raph"
       }
     },
+    {
+      "name": "wizard_school_progress",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "3": "joined_school",
+        "4": "got_blue_triton_horn",
+        "5": "got_slate",
+        "7": "you_are_a_wizard"
+      }
+    },
+    {
+      "name": "find_healing_wizard_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "nothing",
+        "1": "wizard_on_desert_island",
+        "2": "find_magic_school",
+        "3": "found_school_of_magic"
+      }
+    },
+    {
+      "name": "blowgun_test_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "nothing",
+        "1": "started",
+        "2": "passed"
+      }
+    },
     null,
     null,
+    {
+      "name": "sewer_map_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "nothing",
+        "1": "gallic_acid_used",
+        "2": "map_examined"
+      }
+    },
+    null,
+    {
+      "name": "zoe_going_to_see_dinofly",
+      "type": "boolean"
+    },
+    null,
+    {
+      "name": "zeelish_arrived_on_citadel",
+      "type": "boolean"
+    },
+    {
+      "name": "scooter_transport_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "on_scooter",
+        "2": "scooter2"
+      }
+    },
+    {
+      "name": "school_attack_revenge",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "umbrella_thief",
+        "2": "bob",
+        "3": "quetch_big_brother",
+        "4": "umbrella_thief_and_bob",
+        "5": "umbrella_thief_and_quetch_big_brother",
+        "6": "bob_and_quetch_big_brother",
+        "7": "umbrella_thief_and_bob_and_quetch_big_brother"
+      }
+    },
+    null,
+    {
+      "name": "car_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "broken",
+        "1": "got_part",
+        "2": "gave_part_to_zoe",
+        "3": "repaired"
+      }
+    },
     null,
     null,
+    {
+      "name": "bob_wander_state"
+    },
+    {
+      "name": "quetch_big_brother_spawned",
+      "type": "boolean"
+    },
     null,
     null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    {
+      "name": "weather_wizard_disappeared",
+      "type": "boolean"
+    },
     null,
     {
       "name": "zeelish_visits_state",
@@ -290,7 +403,7 @@
         "8": "saw_zoe",
         "9": "back_to_desert",
         "10": "saw_magic_school_director",
-        "11": "captured_the_perl"
+        "11": "captured_the_pearl"
       }
     },
     null,
@@ -304,7 +417,20 @@
     null,
     null,
     {
-      "name": "dino_arrives_on_desert_island",
+      "name": "dinofly_travel_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "on_citadel_island",
+        "2": "on_dome_of_the_slate",
+        "3": "on_desert_island",
+        "4": "on_island_across_from_hacienda",
+        "5": "fly_west",
+        "6": "fly_east"
+      }
+    },
+    {
+      "name": "read_note_from_weather_wizard",
       "type": "boolean"
     },
     null,
@@ -319,9 +445,13 @@
     null,
     null,
     null,
-    null,
-    null,
-    null,
+    {
+      "name": "boat_video_sequence"
+    },
+    {
+      "name": "in_wizard_robes",
+      "type": "boolean"
+    },
     null,
     {
       "name": "read_temple_of_bu_ad",
@@ -337,7 +467,15 @@
       "name": "petanque_sphero_cured",
       "type": "boolean"
     },
+    {
+      "name": "car_is_repaired",
+      "type": "boolean"
+    },
     null,
+    {
+      "name": "seen_island_across_from_hacienda",
+      "type": "boolean"
+    },
     null,
     null,
     null,
@@ -373,16 +511,49 @@
     null,
     null,
     null,
+    {
+      "name": "in_ending_cutscene",
+      "type": "boolean"
+    },
+    {
+      "name": "spying_on_spacecraft",
+      "type": "boolean"
+    },
     null,
     null,
+    {
+      "name": "joe_state",
+      "type": "enum",
+      "enumValues": {
+        "0": "trapped_in_tralu_cave",
+        "1": "stuck_as_a_mussel",
+        "2": "freed"
+      }
+    },
     null,
     null,
+    {
+      "name": "not_in_lupinbourg_statue_area",
+      "type": "boolean"
+    },
+    {
+      "name": "not_in_lupinbourg_landing_area",
+      "type": "boolean"
+    },
     null,
     null,
     null,
+    {
+      "name": "collected_incandescent_pearl",
+      "type": "boolean"
+    },
     null,
     null,
     null,
+    {
+      "name": "not_in_woodbridge",
+      "type": "boolean"
+    },
     null,
     null,
     null,
@@ -449,6 +620,14 @@
     null,
     null,
     null,
+    {
+      "name": "sewer_cloverbox_collected",
+      "type": "boolean"
+    },
+    {
+      "name": "dome_cloverbox_collected",
+      "type": "boolean"
+    },
     null,
     null,
     null,
@@ -456,18 +635,10 @@
     null,
     null,
     null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
-    null,
+    {
+      "name": "transport_override",
+      "type": "boolean"
+    },
     null,
     null,
     null,

--- a/www/metadata/lba2/scene_0.json
+++ b/www/metadata/lba2/scene_0.json
@@ -26,12 +26,17 @@
     "cam_baby_room"
   ],
   "varcubes": [
-    null,
+    {
+      "name": "cellar_door_opened",
+      "type": "boolean"
+    },
     {
       "name": "zoe_talked",
       "type": "boolean"
     },
-    null,
+    {
+      "name": "unused_var2"
+    },
     {
       "name": "said_hello",
       "type": "boolean"

--- a/www/metadata/lba2/scene_1.json
+++ b/www/metadata/lba2/scene_1.json
@@ -23,8 +23,12 @@
     "lamp"
   ],
   "varcubes": [
-    null,
-    null,
+    {
+      "name": "unused_var0"
+    },
+    {
+      "name": "unused_var1"
+    },
     {
       "name": "speaking_through_radio"
     }

--- a/www/metadata/lba2/scene_113.json
+++ b/www/metadata/lba2/scene_113.json
@@ -5,7 +5,7 @@
     "Moya",
     "Pointer",
     "EntrancePointer",
-    "CloverBox",
+    "GiantClam",
     "Mushrooms",
     "Trap"
   ],

--- a/www/metadata/lba2/scene_37.json
+++ b/www/metadata/lba2/scene_37.json
@@ -15,5 +15,61 @@
     "twinsun_poster",
     "room_center",
     "paper_rolls"
+  ],
+  "varcubes": [
+    {
+      "name": "speaking_to",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "kid4",
+        "2": "teacher",
+        "3": "kid1",
+        "4": "kid2",
+        "5": "kid3"
+      }
+    },
+    {
+      "name": "unused_var1"
+    },
+    {
+      "name": "unused_var2"
+    },
+    {
+      "name": "attacked_kid4",
+      "type": "boolean"
+    },
+    {
+      "name": "attacked_kid1",
+      "type": "boolean"
+    },
+    {
+      "name": "attacked_kid2_or_kid3",
+      "type": "boolean"
+    },
+    {
+      "name": "said_hello_to_kid4",
+      "type": "boolean"
+    },
+    {
+      "name": "said_hello_to_kid1",
+      "type": "boolean"
+    },
+    {
+      "name": "said_hello_to_kid2",
+      "type": "boolean"
+    },
+    {
+      "name": "said_hello_to_kid3",
+      "type": "boolean"
+    },
+    {
+      "name": "said_hello_to_teacher",
+      "type": "boolean"
+    },
+    {
+      "name": "twinsen_attacked_kids_or_teacher",
+      "type": "boolean"
+    }
   ]
 }

--- a/www/metadata/lba2/scene_46.json
+++ b/www/metadata/lba2/scene_46.json
@@ -36,5 +36,31 @@
     "lighthouse_door",
     "lighthouse_area_limit2",
     "cam_fork_dead_end"
+  ],
+  "varcubes": [
+    {
+      "name": "in_conversation",
+      "type": "boolean"
+    },
+    {
+      "name": "speaking_to_bersimon_wizard",
+      "type": "boolean"
+    },
+    {
+      "name": "scooter_destination",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "lupin_bourg",
+        "2": "woodbridge_island",
+        "3": "wizards_lane"
+      }
+    },
+    null,
+    null,
+    {
+      "name": "esmers_hostile",
+      "type": "boolean"
+    }
   ]
 }

--- a/www/metadata/lba2/scene_49.json
+++ b/www/metadata/lba2/scene_49.json
@@ -54,5 +54,54 @@
     "to_lighthouse_area",
     "seashore",
     "fork_lighthouse_signal_back"
+  ],
+  "varcubes": [
+    {
+      "name": "in_conversation",
+      "type": "boolean"
+    },
+    {
+      "name": "unused_var1"
+    },
+    {
+      "name": "speaking_to_zoe",
+      "type": "boolean"
+    },
+    {
+      "name": "unused_var3"
+    },
+    {
+      "name": "wrong_way_with_zoe",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "back_to_town",
+        "2": "neighbour_house"
+      }
+    },
+    {
+      "name": "unused_var5"
+    },
+    {
+      "name": "unused_var6"
+    },
+    {
+      "name": "sup_agent_hostile",
+      "type": "boolean"
+    },
+    {
+      "name": "dinofly_destination",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "island_across_from_hacienda",
+        "2": "desert_island",
+        "3": "dome_of_the_slate"
+      }
+    },
+    {
+      "name": "arriving_on_dinofly",
+      "type": "boolean"
+    }
   ]
 }

--- a/www/metadata/lba2/scene_55.json
+++ b/www/metadata/lba2/scene_55.json
@@ -37,5 +37,11 @@
     "cam_dinofly_landing_zone2",
     "cam_dinofly_landing_zone3",
     "cam_dinofly_landing_zone4"
+  ],
+  "varcubes": [
+    {
+      "name": "in_conversation",
+      "type": "boolean"
+    }
   ]
 }

--- a/www/metadata/lba2/scene_73.json
+++ b/www/metadata/lba2/scene_73.json
@@ -16,5 +16,21 @@
     "cam_dinofly_landing_area2",
     "cam_dinofly_landing_area3",
     "to_protection_spell_cave"
+  ],
+  "varcubes": [
+    {
+      "name": "in_conversation",
+      "type": "boolean"
+    },
+    {
+      "name": "dinofly_destination",
+      "type": "enum",
+      "enumValues": {
+        "0": "none",
+        "1": "desert_island",
+        "2": "citadel_island",
+        "3": "dome_of_the_slate"
+      }
+    }
   ]
 }

--- a/www/metadata/lba2/scene_9.json
+++ b/www/metadata/lba2/scene_9.json
@@ -12,5 +12,23 @@
     "desk",
     "paper_rolls",
     "library"
+  ],
+  "varcubes": [
+    {
+      "name": "speaking_to_neighbour",
+      "type": "boolean"
+    },
+    {
+      "name": "said_hello",
+      "type": "boolean"
+    },
+    {
+      "name": "neighbour_speaking",
+      "type": "boolean"
+    },
+    {
+      "name": "looking_at_map",
+      "type": "boolean"
+    }
   ]
 }


### PR DESCRIPTION
Most of the game vars that are referenced from any of the Citadel Island scenes now have names and enumeration values defined. There are also some related scene vars that have been filled out too. Finally, the Pearl Cave "CloverBox" actor has been renamed to "GiantClam" as the scripting indicates that that is its role.

**Preview here:** https://pr-644.lba2remake.net