### PR TITLE
Implement the 'set_sprite' opcode

### DIFF
--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -609,7 +609,9 @@ export function ACTION(this: ScriptContext) {
 
 export const SET_FRAME = unimplemented();
 
-export const SET_SPRITE = unimplemented();
+export function SET_SPRITE(this: ScriptContext, index: number) {
+    this.actor.setSprite(this.scene, index);
+}
 
 export function SET_FRAME_3DS(this: ScriptContext) {
 


### PR DESCRIPTION
This updates the sprite of the actor to the one with the given index.

To test, go to Twinsen's neighbour's house and set the value of game var 66 (with #644  it is called 'sewer_map_state') to a value >= 1 (`GALLIC_ACID_USED`) and the map on the desk will immediately update with the new sprite. To go back to the original sprite, the var needs to be set to 0 and the scene exited (as the life script for the map stops running after updating the sprite).

This also works for the various switches in the world (e.g. in Lupin-Bourg's sewers).

**Preview here:** https://pr-645.lba2remake.net