### PR TITLE
Implement var_game_to_track and track_to_var_game

### DIFF
--- a/src/game/scene/variables.ts
+++ b/src/game/scene/variables.ts
@@ -26,7 +26,9 @@ export function findUsedVarGames(actors: Actor[]) {
         const commands = actor.scripts.life.commands;
         for (const cmd of commands) {
             let value = null;
-            if (cmd.op.command === 'SET_VAR_GAME') {
+            if (cmd.op.command === 'SET_VAR_GAME'
+                || cmd.op.command === 'TRACK_TO_VAR_GAME'
+                || cmd.op.command === 'VAR_GAME_TO_TRACK') {
                 value = cmd.args[0].value;
             } else if (cmd.condition && cmd.condition.op.command === 'VAR_GAME') {
                 value = cmd.condition.param.value;

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -13,6 +13,8 @@ import { getParams } from '../../params';
 import { initWagonState } from '../gameplay/wagon';
 import { LBA2Items, GetInventoryItems, LBA1Items } from '../data/inventory';
 import Extra, { getBonus } from '../Extra';
+import { CURRENT_TRACK, VAR_GAME } from './condition';
+import { SET_TRACK } from './structural';
 
 const isLBA1 = getParams().game === 'lba1';
 
@@ -664,9 +666,13 @@ export function PLAY_MUSIC(this: ScriptContext, index) {
     audio.playMusic(index);
 }
 
-export const TRACK_TO_VAR_GAME = unimplemented();
+export function TRACK_TO_VAR_GAME(this: ScriptContext, index) {
+    SET_VAR_GAME.call(this, index, CURRENT_TRACK.call(this));
+}
 
-export const VAR_GAME_TO_TRACK = unimplemented();
+export function VAR_GAME_TO_TRACK(this: ScriptContext, index) {
+    SET_TRACK.call(this, VAR_GAME.call(this, index));
+}
 
 export const ANIM_TEXTURE = unimplemented();
 


### PR DESCRIPTION
These opcodes load/store the current move track of an actor from/to a game var. Also check these opcodes when building the "only in scene" game var list in the editor.

The main use of these opcodes seems to be for implementing timers. For example, most (all?) areas on Desert Island contain an invisible actor (e.g. actor_19 in the School of Magic Classroom) that has a move script which has a chain of tracks and waits and a life script that continually saves the current track to a game var (var_80). This var is then used to drive the state of the Peddler as he travels around the island.

**Preview here:** https://pr-646.lba2remake.net