### PR TITLE
Implement the 'no_shock' opcode

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -119,6 +119,7 @@ export interface ActorState {
     floorSound: number;
     floorSound2: number;
     nextAnim: number;
+    noShock: boolean;
 }
 
 export enum SlideWay {
@@ -672,6 +673,11 @@ export default class Actor {
     }
 
     hit(hitBy, hitStrength) {
+        // If the actor is flagged 'noShock', all hit effects are ignored.
+        if (this.state.noShock) {
+            return;
+        }
+
         if (this.sprite) {
             this.state.wasHitBy = hitBy;
             return;
@@ -822,6 +828,7 @@ export default class Actor {
             floorSound: -1,
             floorSound2: -1,
             nextAnim: null,
+            noShock: false,
         };
     }
 }

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -625,7 +625,9 @@ export function ADD_MESSAGE(this: ScriptContext, cmdState, id) {
 
 export const BALLOON = unimplemented();
 
-export const NO_SHOCK = unimplemented();
+export function NO_SHOCK(this: ScriptContext, flag: number) {
+    this.actor.state.noShock = (flag !== 0);
+}
 
 export function CINEMA_MODE(this: ScriptContext, mode) {
     if (mode > 0) {

--- a/src/ui/editor/areas/gameplay/scripts/blocks/blocksLibrary/life/actions.ts
+++ b/src/ui/editor/areas/gameplay/scripts/blocks/blocksLibrary/life/actions.ts
@@ -490,7 +490,7 @@ export const lba_obj_col = action((_block, field) => {
 });
 
 export const lba_no_shock = action((_block, field) => {
-    field('(?) no shock');
+    field('no shock');
     field(new Blockly.FieldNumber(), 'arg_0');
 });
 


### PR DESCRIPTION
This opcode blocks any hit processing when enabled for an actor (no damage animations are played; no damage is taken; and hit_by is not set).