### PR TITLE
Implement armour and related opcodes

### DIFF
--- a/src/game/Actor.ts
+++ b/src/game/Actor.ts
@@ -43,6 +43,7 @@ export interface ActorProps {
     sceneIndex: number;
     pos: [number, number, number];
     life: number;
+    armour: number;
     flags: ActorFlags;
     entityIndex: number;
     bodyIndex: number;
@@ -678,12 +679,13 @@ export default class Actor {
         }
 
         let life = -1;
-        // TODO(scottwilliams): This doesn't take into account actor armour.
+        const armour = this.props.armour;
+        const damage = Math.max(0, hitStrength - armour);
         if (this.index === 0) {
-            this.game.getState().hero.life -= hitStrength;
+            this.game.getState().hero.life -= damage;
             life = this.game.getState().hero.life;
         } else {
-            this.props.life -= hitStrength;
+            this.props.life -= damage;
             life = this.props.life;
         }
 
@@ -887,6 +889,7 @@ export function createNewActorProps(
         index: scene.actors.length,
         pos: details.position.toArray() as any,
         life: 255,
+        armour: 0,
         flags: {
             hasCollisions: true,
             hasCollisionBricks: true,

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -447,9 +447,8 @@ export function SUB_LIFE_POINT_OBJ(this: ScriptContext, actor: Actor, value) {
     }
 }
 
-export function HIT(this: ScriptContext, actor: Actor, strength) {
-    actor.state.wasHitBy = this.actor.index;
-    actor.props.life -= strength;
+export function HIT(this: ScriptContext, actor: Actor, strength: number) {
+    actor.hit(this.actor, strength);
 }
 
 export function PLAY_VIDEO(this: ScriptContext, cmdState, video: string) {
@@ -684,9 +683,13 @@ export const REPLACE = unimplemented();
 
 export const SCALE = unimplemented();
 
-export const SET_ARMOR = unimplemented();
+export function SET_ARMOR(this: ScriptContext, value: number) {
+    SET_ARMOR_OBJ.call(this, this.actor, value);
+}
 
-export const SET_ARMOR_OBJ = unimplemented();
+export function SET_ARMOR_OBJ(this: ScriptContext, actor: Actor, value: number) {
+    actor.props.armour = value;
+}
 
 export function ADD_LIFE_POINT_OBJ(this: ScriptContext, index, points) {
     const actor = this.scene.actors[index];


### PR DESCRIPTION
Armour provides a flat reduction to incoming damage. If all the damage is blocked, the hit animations and logic still play but no life points are subtracted.

The LBA2 data files tend to set an armour value of 51 for unkillable actors. No special coding for this value has been added; magic ball damage tops out at 40 so such actors are functionally invincible.

**Preview here:** https://pr-648.lba2remake.net