### PR TITLE
Inventory state tracking

### DIFF
--- a/src/game/GameState.ts
+++ b/src/game/GameState.ts
@@ -5,6 +5,7 @@ import { getParams } from '../params';
 import Actor from './Actor';
 import AnimState from '../model/anim/AnimState';
 import { AnimStateJSON } from '../model/anim/types';
+import { GetInventorySize, LBA2Items } from './data/inventory';
 
 export interface GameConfig {
     displayText: boolean;
@@ -92,6 +93,7 @@ export function createGameState(): GameState {
         actorTalking: -1,
         flags: {
             quest: createQuestFlags(),
+            inventory: createInventoryFlags(),
             holomap: createHolomapFlags()
         },
         save(hero: Actor) {
@@ -140,6 +142,15 @@ function createQuestFlags() {
     return quest;
 }
 
+function createInventoryFlags() {
+    const inventory = [];
+    for (let i = 0; i < GetInventorySize(); i += 1) {
+        inventory[i] = 0;
+    }
+
+    return inventory;
+}
+
 function createHolomapFlags() {
     const holomap = [];
     for (let i = 0; i < 512; i += 1) {
@@ -184,4 +195,10 @@ export function setMagicBallLevel(state: GameState, index: number) {
 
     state.hero.magicball = magicball;
     state.hero.handStrength = handStrength;
+
+    // Update the magic ball and ring of lightning item states.
+    state.flags.inventory[LBA2Items.MAGIC_BALL] = index;
+    if (getParams().game === 'lba2') {
+        state.flags.inventory[LBA2Items.RING_OF_LIGHTNING] = index;
+    }
 }

--- a/src/game/data/inventory.ts
+++ b/src/game/data/inventory.ts
@@ -12,6 +12,8 @@ const LBA2InventoryRows = 5;
 const LBA1InventoryColumns = 7;
 const LBA1InventoryRows = 4;
 
+// This list corresponds with the game vars for each item, which is mostly but not entirely the
+// same as the indices used for the item modems and strings.
 export enum LBA2Items {
     HOLOMAP = 0,
     MAGIC_BALL = 1,
@@ -22,7 +24,7 @@ export enum LBA2Items {
     PYRAMID_KEY = 6,
     CAR_PART = 7,
     KASHES = 8,
-    LASER_PISTOL_NO_CRYSTAL = 9,
+    LASER_PISTOL = 9,
     SWORD = 10,
     WANNIE_GLOVE = 11,
     PROTO_PACK = 12,
@@ -37,7 +39,7 @@ export enum LBA2Items {
     GEM = 21,
     HORN = 22,
     BLOWGUN = 23,
-    ITINERARY_TOKEN = 24,
+    MEMORY_VIEWER = 24,
     SLICE_OF_TART = 25,
     RADIO = 26,
     GARDEN_BALSAM = 27,
@@ -53,17 +55,19 @@ export enum LBA2Items {
     BURGERMASTER_KEY = 37,
     BURGERMASTER_NOTES = 38,
     PROTECTIVE_SPELL = 39,
+
+    // Items below this point are "virtual" - they do not have associated game vars.
     GREEN_MAGIC_BALL = 40,
     RED_MAGIC_BALL = 41,
     FIRE_MAGIC_BALL = 42,
     ZLITOS = 43,
     DARK_MONK_KEY = 44,
-    MEMORY_VIEWER = 45,
+    TRAVEL_TOKEN = 45,
     BLOWTRON = 46,
     WIZARDS_TUNIC = 47,
     JET_PACK = 48,
-    CRYSTAL_PIECE = 49,
-    LASER_PISTON_WITH_CRYSTAL = 50,
+    LASER_PISTOL_CRYSTAL_PIECE = 49,
+    LASER_PISTOL_BODY = 50,
     GREEN_RING_OF_LIGHTNING = 51,
     RED_RING_OF_LIGHTNING = 52,
     FIRE_RING_OF_LIGHTNING = 53,
@@ -107,7 +111,7 @@ const LBA2InventoryMapping = {
     2: LBA2Items.BLOWGUN,
     3: LBA2Items.HORN,
     4: LBA2Items.WANNIE_GLOVE,
-    5: LBA2Items.LASER_PISTON_WITH_CRYSTAL,
+    5: LBA2Items.LASER_PISTOL,
     6: LBA2Items.SWORD,
     7: LBA2Items.TUNIC,
     8: LBA2Items.SENDELLS_BALL,
@@ -172,11 +176,15 @@ const LBA1InventoryMapping = {
 
 export const LBA2WeaponToBodyMapping = {
     [LBA2Items.MAGIC_BALL]: LBA2BodyType.TWINSEN_TUNIC,
+    [LBA2Items.GREEN_MAGIC_BALL]: LBA2BodyType.TWINSEN_TUNIC,
+    [LBA2Items.RED_MAGIC_BALL]: LBA2BodyType.TWINSEN_TUNIC,
+    [LBA2Items.FIRE_MAGIC_BALL]: LBA2BodyType.TWINSEN_TUNIC,
     [LBA2Items.DARTS]: LBA2BodyType.TWINSEN_TUNIC,
-    [LBA2Items.LASER_PISTON_WITH_CRYSTAL]: LBA2BodyType.TWINSEN_LASER_PISTOL,
+    [LBA2Items.LASER_PISTOL]: LBA2BodyType.TWINSEN_LASER_PISTOL,
     [LBA2Items.SWORD]: LBA2BodyType.TWINSEN_SWORD,
     [LBA2Items.WANNIE_GLOVE]: LBA2BodyType.TWINSEN_WANNIE_GLOVE,
     [LBA2Items.BLOWGUN]: LBA2BodyType.TWINSEN_BLOWGUN,
+    [LBA2Items.BLOWTRON]: LBA2BodyType.TWINSEN_BLOWTRON,
 };
 
 export const LBA1WeaponToBodyMapping = {
@@ -206,5 +214,127 @@ export const LBA2InventorySize = 40;
 
 export function GetInventorySize() {
     return isLBA1 ? LBA1InventorySize : LBA2InventorySize;
+}
+
+function MapItemLBA1(item: number, _state: number) {
+    // Not implemented.
+    return item;
+}
+
+function MapItemLBA2(item: number, state: number) {
+    switch (item as LBA2Items)
+    {
+        case LBA2Items.MAGIC_BALL:
+            return GetLBA2MagicBallForLevel(state);
+
+        case LBA2Items.TUNIC:
+            return (state === 1) ? LBA2Items.WIZARDS_TUNIC : LBA2Items.TUNIC;
+
+        case LBA2Items.PEARL_OF_INCANDESCENCE:
+            return (state === 1) ? LBA2Items.TRAVEL_TOKEN : LBA2Items.PEARL_OF_INCANDESCENCE;
+
+        case LBA2Items.KASHES:
+            // TODO: how does original LBA2 decide Kashes vs Zlitos here?
+            return LBA2Items.ZLITOS;
+
+        case LBA2Items.LASER_PISTOL:
+            if (state === 0) {
+                return LBA2Items.LASER_PISTOL_CRYSTAL_PIECE;
+            }
+            if (state === 1) {
+                return LBA2Items.LASER_PISTOL_BODY;
+            }
+            return LBA2Items.LASER_PISTOL;
+
+        case LBA2Items.PROTO_PACK:
+            return (state === 1) ? LBA2Items.JET_PACK : LBA2Items.PROTO_PACK;
+
+        case LBA2Items.RING_OF_LIGHTNING:
+            return GetLBA2RingOfLightningForLevel(state);
+
+        case LBA2Items.BLOWGUN:
+            return (state === 1) ? LBA2Items.BLOWTRON : LBA2Items.BLOWGUN;
+
+        case LBA2Items.FRAGMENT_FRANCOS:
+            return (state === 1) ? LBA2Items.DARK_MONK_KEY : LBA2Items.FRAGMENT_FRANCOS;
+
+        default:
+            // Most items have no special states.
+            return item;
+    }
+}
+
+export function MapItem(item: number, state: number) {
+    return isLBA1 ? MapItemLBA1(item, state) : MapItemLBA2(item, state);
+}
+
+export function GetLBA2MagicBallForLevel(level: number) {
+    switch (level)
+    {
+        case 2:
+            return LBA2Items.GREEN_MAGIC_BALL;
+
+        case 3:
+            return LBA2Items.RED_MAGIC_BALL;
+
+        case 4:
+            return LBA2Items.FIRE_MAGIC_BALL;
+
+        case 0:
+        case 1:
+        default:
+            return LBA2Items.MAGIC_BALL;
+    }
+}
+
+export function GetLBA2RingOfLightningForLevel(level: number) {
+    switch (level)
+    {
+        case 2:
+            return LBA2Items.GREEN_RING_OF_LIGHTNING;
+
+        case 3:
+            return LBA2Items.RED_RING_OF_LIGHTNING;
+
+        case 4:
+            return LBA2Items.FIRE_RING_OF_LIGHTNING;
+
+        case 0:
+        case 1:
+        default:
+            return LBA2Items.RING_OF_LIGHTNING;
+    }
+}
+
+function GetLBA1ItemResourceIndex(item: LBA1Items) {
+    // TODO: check if any mapping is needed.
+    return item as number;
+}
+
+function GetLBA2ItemResourceIndex(item: LBA2Items) {
+    switch (item)
+    {
+        case LBA2Items.LASER_PISTOL:
+            return 50;
+
+        case LBA2Items.MEMORY_VIEWER:
+            return 45;
+
+        case LBA2Items.TRAVEL_TOKEN:
+            return 24;
+
+        case LBA2Items.LASER_PISTOL_BODY:
+            return 9;
+
+        default:
+            // Most items require no mapping.
+            return item as number;
+    }
+}
+
+export function GetItemResourceIndex(item: LBA1Items|LBA2Items) {
+    return isLBA1
+        ? GetLBA1ItemResourceIndex(item as LBA1Items)
+        : GetLBA2ItemResourceIndex(item as LBA2Items);
 }
 

--- a/src/game/data/inventory.ts
+++ b/src/game/data/inventory.ts
@@ -224,6 +224,27 @@ export function GetInventorySize() {
     return isLBA1 ? LBA1InventorySize : LBA2InventorySize;
 }
 
+function CanUseItemLBA1(_item: LBA1Items) {
+    // Not implemented - assume all items are always usable.
+    return true;
+}
+
+function CanUseItemLBA2(item: LBA2Items) {
+    switch (item)
+    {
+        case LBA2Items.LASER_PISTOL_CRYSTAL_PIECE:
+        case LBA2Items.LASER_PISTOL_BODY:
+            return false;
+
+        default:
+            return true;
+    }
+}
+
+export function CanUseItem(item: LBA1Items|LBA2Items) {
+    return isLBA1 ? CanUseItemLBA1(item as LBA1Items) : CanUseItemLBA2(item as LBA2Items);
+}
+
 function MapItemLBA1(item: number, _state: number) {
     // Not implemented.
     return item;

--- a/src/game/data/inventory.ts
+++ b/src/game/data/inventory.ts
@@ -199,3 +199,12 @@ export function GetInventoryColumns() {
 export function GetInventoryItems() {
     return isLBA1 ? LBA1Items : LBA2Items;
 }
+
+export const LBA1InventorySize = 28;
+
+export const LBA2InventorySize = 40;
+
+export function GetInventorySize() {
+    return isLBA1 ? LBA1InventorySize : LBA2InventorySize;
+}
+

--- a/src/game/data/inventory.ts
+++ b/src/game/data/inventory.ts
@@ -7,7 +7,7 @@ import { getParams } from '../../params';
 const isLBA1 = getParams().game === 'lba1';
 
 const LBA2InventoryColumns = 7;
-const LBA2InventoryRows = 5;
+const LBA2InventoryRows = 6;    // Original: 5, but it overloaded some slots.
 
 const LBA1InventoryColumns = 7;
 const LBA1InventoryRows = 4;
@@ -123,24 +123,32 @@ const LBA2InventoryMapping = {
     14: LBA2Items.HOLOMAP,
     15: LBA2Items.PROTO_PACK,
     16: LBA2Items.RADIO,
-    17: LBA2Items.TRANSLATOR,
-    18: LBA2Items.TRANSLATOR,
+    17: LBA2Items.TRANSLATOR,           // Original: also CAR_PART
+    18: LBA2Items.MECA_PENGUIN,
     19: LBA2Items.KASHES,
     20: LBA2Items.FRAGMENT_SUPS,
     21: LBA2Items.FERRYMAN_SONG,
     22: LBA2Items.SLICE_OF_TART,
-    23: LBA2Items.ISLAND_CX_KEY,
+    23: LBA2Items.ISLAND_CX_KEY,        // Original: also GARDEN_BALSAM
     24: LBA2Items.GEM,
     25: LBA2Items.PEARL_OF_INCANDESCENCE,
-    26: LBA2Items.PICKAXE,
+    26: LBA2Items.PICKAXE,              // Original: also GALLIC_ACID
     27: LBA2Items.FRAGMENT_MOSQUIBEES,
     28: LBA2Items.GAZOGEM,
     29: LBA2Items.DISSIDENTS_RING,
     30: LBA2Items.UMBRELLA,
     31: LBA2Items.MEMORY_VIEWER,
     32: LBA2Items.FERRY_TICKET,
-    33: LBA2Items.BURGERMASTER_NOTES,
+    33: LBA2Items.BURGERMASTER_NOTES,   // Original: also PYRAMID_KEY, BURGERMASTER_KEY
     34: LBA2Items.FRAGMENT_WANNIES,
+
+    // The following items are overloaded onto other item slots in the original but we don't need
+    // to keep the same design.
+    35: LBA2Items.PYRAMID_KEY,
+    36: LBA2Items.GALLIC_ACID,
+    37: LBA2Items.GARDEN_BALSAM,
+    38: LBA2Items.CAR_PART,
+    39: LBA2Items.BURGERMASTER_KEY,
 };
 
 const LBA1InventoryMapping = {

--- a/src/game/data/inventory.ts
+++ b/src/game/data/inventory.ts
@@ -337,4 +337,3 @@ export function GetItemResourceIndex(item: LBA1Items|LBA2Items) {
         ? GetLBA1ItemResourceIndex(item as LBA1Items)
         : GetLBA2ItemResourceIndex(item as LBA2Items);
 }
-

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -559,7 +559,7 @@ function processActorMovement(
                     case LBA2Items.WANNIE_GLOVE:
                         animIndex = AnimType.WANNIE_GLOVE_SWING;
                         break;
-                    case LBA2Items.LASER_PISTON_WITH_CRYSTAL:
+                    case LBA2Items.LASER_PISTOL:
                         animIndex = AnimType.LASTER_PISTOL_SHOOT;
                         break;
                     case LBA1Items.FUNFROCK_SABER:
@@ -703,4 +703,23 @@ function processCamRelativeMovement(
         }
     }
     return animIndex;
+}
+
+export function heroUseItem(game: Game, rawItemId: number, itemId?: number) {
+    if (!itemId) {
+        itemId = rawItemId;
+    }
+
+    // Use the raw item ID here as it will be passed to scripts.
+    game.getState().hero.usingItemId = rawItemId;
+
+    // Reset the usingItemId after a single game loop execution.
+    game.addLoopFunction(null, () => {
+        game.getState().hero.usingItemId = -1;
+    });
+
+    if (itemId in LBA2WeaponToBodyMapping) {
+        // Use the mapped item ID here as it affects Twinsen's model.
+        game.getState().hero.equippedItemId = itemId;
+    }
 }

--- a/src/game/loop/hero.ts
+++ b/src/game/loop/hero.ts
@@ -104,6 +104,9 @@ export function getBodyFromGameState(game: Game): number {
             return -1;
         }
         if (game.getState().flags.quest[LBA2Items.TUNIC]) {
+            if (game.getState().flags.inventory[LBA2Items.TUNIC] === 1) {
+                return LBA2BodyType.TWINSEN_WIZARD;
+            }
             return LBA2BodyType.TWINSEN_TUNIC;
         }
         return LBA2BodyType.TWINSEN_NO_TUNIC;
@@ -114,9 +117,20 @@ export function getBodyFromGameState(game: Game): number {
     }
 
     const body = LBA2WeaponToBodyMapping[equippedItem];
-    if (body === LBA2BodyType.TWINSEN_TUNIC && !game.getState().flags.quest[LBA2Items.TUNIC]) {
+    const tunic = game.getState().flags.quest[LBA2Items.TUNIC];
+    const wizard = tunic && game.getState().flags.inventory[LBA2Items.TUNIC] === 1;
+
+    // Special cases.
+    if (body === LBA2BodyType.TWINSEN_TUNIC && !tunic) {
         return LBA2BodyType.TWINSEN_NO_TUNIC;
     }
+    if (body === LBA2BodyType.TWINSEN_BLOWGUN && wizard) {
+        return LBA2BodyType.TWINSEN_WIZARD_BLOWGUN;
+    }
+    if (body === LBA2BodyType.TWINSEN_TUNIC && wizard) {
+        return LBA2BodyType.TWINSEN_WIZARD;
+    }
+
     return body;
 }
 

--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -11,7 +11,7 @@ import { getVideoPath } from '../../resources';
 import { ScriptContext } from './ScriptContext';
 import { getParams } from '../../params';
 import { initWagonState } from '../gameplay/wagon';
-import { LBA2Items, GetInventoryItems, LBA1Items } from '../data/inventory';
+import { LBA2Items, GetInventoryItems, LBA1Items, GetInventorySize } from '../data/inventory';
 import Extra, { getBonus } from '../Extra';
 import { CURRENT_TRACK, VAR_GAME } from './condition';
 import { SET_TRACK } from './structural';
@@ -498,8 +498,8 @@ export function INC_CLOVER_BOX(this: ScriptContext) {
 }
 
 export function SET_USED_INVENTORY(this: ScriptContext, item) {
-    if (item < 40) {
-        this.game.getState().flags.quest[item] = 1;
+    if (item < GetInventorySize()) {
+        this.game.getState().hero.usingItemId = item;
     }
 }
 
@@ -707,7 +707,9 @@ export function ADD_LIFE_POINT_OBJ(this: ScriptContext, index, points) {
     }
 }
 
-export const STATE_INVENTORY = unimplemented();
+export function STATE_INVENTORY(this: ScriptContext, item: number, state: number) {
+    this.game.getState().flags.inventory[item] = state;
+}
 
 export const SET_HIT_ZONE = unimplemented();
 

--- a/src/ui/editor/areas/gameplay/scene/SceneNode.tsx
+++ b/src/ui/editor/areas/gameplay/scene/SceneNode.tsx
@@ -7,6 +7,7 @@ import {PointsNode} from './nodes/PointsNode';
 import {makeVarDef, makeVariables, Var} from './node_factories/variables';
 import LocationsNode from '../locator/LocationsNode';
 import Scene from '../../../../../game/Scene';
+import { GetInventorySize } from '../../../../../game/data/inventory';
 
 const VarCube = makeVariables('varcube', 'Scene Variables', (scene) => {
     if (scene) {
@@ -38,14 +39,16 @@ const VarGame = {
                 if (VarGameConfig.filterInventory) {
                     let count = 0;
                     each(scene.usedVarGames, (varGame) => {
-                        if (varGame < 40)
+                        if (varGame < GetInventorySize())
                             count += 1;
                     });
                     return count;
                 }
                 return scene.usedVarGames.length;
             }
-            return VarGameConfig.filterInventory ? 40 : game.getState().flags.quest.length;
+            return VarGameConfig.filterInventory
+                ? GetInventorySize()
+                : game.getState().flags.quest.length;
         }
         return 0;
     },
@@ -56,7 +59,7 @@ const VarGame = {
             const state = game.getState();
             if (VarGameConfig.filterScene) {
                 const usedVarGames = VarGameConfig.filterInventory
-                    ? filter(scene.usedVarGames, vg => vg < 40)
+                    ? filter(scene.usedVarGames, vg => vg < GetInventorySize())
                     : scene.usedVarGames;
                 const varGame = usedVarGames[idx];
                 if (varGame !== undefined) {

--- a/src/ui/editor/areas/gameplay/scripts/VariablesPanel.tsx
+++ b/src/ui/editor/areas/gameplay/scripts/VariablesPanel.tsx
@@ -5,6 +5,7 @@ import { scopeColors } from './blocks/blocksLibrary/utils';
 import { fullscreen } from '../../../../styles';
 import DebugData from '../../../DebugData';
 import Scene from '../../../../../game/Scene';
+import { GetInventorySize } from '../../../../../game/data/inventory';
 
 const darker = (c) => {
     const hsl = convert.hex.hsl(c);
@@ -91,7 +92,7 @@ const scopes = [
                 return [];
             }
             const vars = game.getState().flags.quest;
-            return mapVariables(drop(vars, 40), { offset: 40, type: 'game' });
+            return mapVariables(drop(vars, GetInventorySize()), { offset: GetInventorySize(), type: 'game' });
         }
     },
     {
@@ -103,7 +104,7 @@ const scopes = [
                 return [];
             }
             const vars = game.getState().flags.quest;
-            return mapVariables(take(vars, 40), { type: 'game' });
+            return mapVariables(take(vars, GetInventorySize()), { type: 'game' });
         }
     },
     {

--- a/src/ui/editor/areas/gameplay/scripts/blocks/blocksLibrary/utils/optionsGenerators.ts
+++ b/src/ui/editor/areas/gameplay/scripts/blocks/blocksLibrary/utils/optionsGenerators.ts
@@ -2,6 +2,7 @@ import { map, filter, take, drop, each, sortBy } from 'lodash';
 import DebugData, { getVarName, getObjectName } from '../../../../../../DebugData';
 import LocationsNode from '../../../../locator/LocationsNode';
 import { ActorDirMode } from '../../../../../../../../game/Actor';
+import { GetInventorySize } from '../../../../../../../../game/data/inventory';
 
 function getActor(field) {
     const block = field.getSourceBlock();
@@ -166,10 +167,11 @@ function generateVarGame(inventory) {
     if (!game) {
         return [['<vargame>', '-1']];
     }
+    const inventorySize = GetInventorySize();
     const vars = inventory
-        ? take(game.getState().flags.quest, 40)
-        : drop(game.getState().flags.quest, 40);
-    const offset = inventory ? 0 : 40;
+        ? take(game.getState().flags.quest, inventorySize)
+        : drop(game.getState().flags.quest, inventorySize);
+    const offset = inventory ? 0 : inventorySize;
     return map(
         vars,
         (_value, idx) => {

--- a/src/ui/editor/areas/gameplay/scripts/blocks/scriptToBlocks/extractors/conditions.ts
+++ b/src/ui/editor/areas/gameplay/scripts/blocks/scriptToBlocks/extractors/conditions.ts
@@ -1,3 +1,4 @@
+import { GetInventorySize } from '../../../../../../../../game/data/inventory';
 import { GENERIC_CONDITION, newBlock } from './utils';
 
 export const COL = GENERIC_CONDITION.bind(null, 'lba_collision', false);
@@ -50,7 +51,7 @@ export const OBJECT_DISPLAYED = GENERIC_CONDITION.bind(null, 'lba_object_display
 function VAR_CONDITION(scope, workspace, cmd, { connection }) {
     const block = newBlock(workspace, 'lba_var_value', cmd);
     const cond = cmd.data.condition;
-    if (scope === 'game' && cond.param.value < 40) {
+    if (scope === 'game' && cond.param.value < GetInventorySize()) {
         scope = 'inventory';
     }
     block.setFieldValue(scope, 'scope');

--- a/src/ui/editor/areas/gameplay/scripts/blocks/scriptToBlocks/extractors/life.ts
+++ b/src/ui/editor/areas/gameplay/scripts/blocks/scriptToBlocks/extractors/life.ts
@@ -6,6 +6,7 @@ import {
 } from './utils';
 import { GENERIC_IF, LOGIC_OPERATOR } from './control';
 import { lbaToDegrees } from '../../../../../../../../utils/lba';
+import { GetInventorySize } from '../../../../../../../../game/data/inventory';
 
 /*
 ** Behaviours
@@ -113,7 +114,7 @@ function GENERIC_SETTER(type, scope, workspace, cmd, {connection}) {
         connection.connect(block.previousConnection);
     }
     const varIndex = cmd.data.args[0].value;
-    if (scope === 'game' && varIndex < 40) {
+    if (scope === 'game' && varIndex < GetInventorySize()) {
         scope = 'inventory';
     }
     block.setFieldValue(scope, 'scope');

--- a/src/ui/editor/areas/gameplay/scripts/text/TextEditor.tsx
+++ b/src/ui/editor/areas/gameplay/scripts/text/TextEditor.tsx
@@ -7,6 +7,7 @@ import DebugData from '../../../../DebugData';
 import { TickerProps } from '../../../../../utils/Ticker';
 import { scopeColors } from '../blocks/blocksLibrary/utils';
 import Scene from '../../../../../../game/Scene';
+import { GetInventorySize } from '../../../../../../game/data/inventory';
 
 const defaultSplitDistance = 60;
 
@@ -405,10 +406,10 @@ function getScope(cmd) {
     }
     if (baseScope === 'game') {
         if (cmd.name === 'VAR_GAME' || cmd.name === 'VAR_CUBE') {
-            if (cmd.param.realValue < 40) {
+            if (cmd.param.realValue < GetInventorySize()) {
                 return 'inventory';
             }
-        } else if (cmd.args[0].realValue < 40) {
+        } else if (cmd.args[0].realValue < GetInventorySize()) {
             return 'inventory';
         }
     }

--- a/src/ui/game/Inventory.tsx
+++ b/src/ui/game/Inventory.tsx
@@ -168,7 +168,7 @@ const Inventory = ({ game, closeInventory }: any) => {
             const slot = game.getState().hero.inventorySlot;
             const rawItemId = GetInventoryMapping()[slot];
             const itemId = resolveItem(slot);
-            if (game.getState().flags.quest[rawItemId] >= 1) {
+            if (game.getState().flags.quest[rawItemId] >= 1 && CanUseItem(itemId)) {
                 heroUseItem(game, rawItemId, itemId);
                 closeInventory();
             } else {

--- a/src/ui/game/Inventory.tsx
+++ b/src/ui/game/Inventory.tsx
@@ -3,7 +3,14 @@ import * as THREE from 'three';
 import React, { useEffect, useState, useRef } from 'react';
 
 import SampleType from '../../game/data/sampleType';
-import { GetInventoryMapping, GetInventoryRows, GetInventoryColumns, LBA2WeaponToBodyMapping } from '../../game/data/inventory';
+import {
+    GetInventoryMapping,
+    GetInventoryRows,
+    GetInventoryColumns,
+    GetItemResourceIndex,
+    MapItem,
+    CanUseItem,
+} from '../../game/data/inventory';
 import { getText } from '../../resources';
 import '../styles/inventory.scss';
 import {
@@ -15,6 +22,7 @@ import {
 } from './overlay';
 import { ControlsState } from '../../game/ControlsState';
 import { getParams } from '../../params';
+import { heroUseItem } from '../../game/loop/hero';
 
 const InventoryObjectsIndex = 4;
 const InventoryTextOffset = 100;
@@ -23,7 +31,6 @@ const isLBA1 = getParams().game === 'lba1';
 
 const Inventory = ({ game, closeInventory }: any) => {
     const [selectedSlot, setSelectedSlot] = useState(game.getState().hero.inventorySlot);
-    const [equippedItem, setEquippedItem] = useState(game.getState().hero.equippedItemId);
     const [clock, setClock] = useState(null);
     const [canvas, setCanvas] = useState(null);
     const [renderer, setRenderer] = useState(null);
@@ -39,6 +46,20 @@ const Inventory = ({ game, closeInventory }: any) => {
             itemNodes[slot] = useRef(null);
         }
     }
+
+    const resolveItem = (slot: number) => {
+        const rawItemId = GetInventoryMapping()[slot];
+        const inventoryFlags = game.getState().flags.inventory;
+        const state = inventoryFlags[rawItemId];
+        const itemId = MapItem(rawItemId, state);
+        return itemId;
+    };
+
+    const resolveItemResource = (slot: number) => {
+        const itemId = resolveItem(slot);
+        const resourceId = GetItemResourceIndex(itemId);
+        return resourceId;
+    };
 
     useEffect(() => {
         setClock(createOverlayClock());
@@ -72,9 +93,18 @@ const Inventory = ({ game, closeInventory }: any) => {
         };
     }, [renderer]);
 
-    const loadModel = async (slot) => {
-        models[slot] = await loadSceneInventoryModel(invScenes[slot], GetInventoryMapping()[slot]);
+    const loadModelForResource = async (slot: number, resource: number) => {
+        models[slot] = {
+            model: await loadSceneInventoryModel(invScenes[slot], resource),
+            resourceId: resource,
+        };
         setModels(models);
+    };
+
+    const loadModel = async (slot) => {
+        // Models depend on the item state (e.g. blowgun vs blowtron).
+        const resourceId = resolveItemResource(slot);
+        await loadModelForResource(slot, resourceId);
     };
 
    useEffect(() => {
@@ -134,17 +164,12 @@ const Inventory = ({ game, closeInventory }: any) => {
             action = true;
         }
         if (key === 'Enter' || controlsState?.action === 1) {
-            const itemId = GetInventoryMapping()[game.getState().hero.inventorySlot];
-            if (game.getState().flags.quest[itemId] >= 1) {
-                game.getState().hero.usingItemId = itemId;
-                // Reset the usingItemId after a single game loop execution.
-                game.addLoopFunction(null, () => {
-                    game.getState().hero.usingItemId = -1;
-                });
-                if (itemId in LBA2WeaponToBodyMapping) {
-                    setEquippedItem(itemId);
-                    game.getState().hero.equippedItemId = itemId;
-                }
+            // Use the raw (state-independent) item ID here as it may trigger script actions.
+            const slot = game.getState().hero.inventorySlot;
+            const rawItemId = GetInventoryMapping()[slot];
+            const itemId = resolveItem(slot);
+            if (game.getState().flags.quest[rawItemId] >= 1) {
+                heroUseItem(game, rawItemId, itemId);
                 closeInventory();
             } else {
                 game.getAudioManager().playSample(SampleType.ERROR);
@@ -179,9 +204,18 @@ const Inventory = ({ game, closeInventory }: any) => {
     });
 
     const renderLoop = (time, slot, selected, item) => {
-        const m = models[slot];
+        const model = models[slot];
+        const m = model?.model;
 
         if (!item || !item.current || !m) {
+            return;
+        }
+
+        // If the item state has changed, request a reload and skip rendering.
+        const resourceId = resolveItemResource(slot);
+        if (model.resourceId !== resourceId) {
+            models[slot] = null;
+            loadModelForResource(slot, resourceId);
             return;
         }
 
@@ -239,11 +273,13 @@ const Inventory = ({ game, closeInventory }: any) => {
     }, [renderer, selectedSlot]);
 
     useEffect(() => {
+        // Text depends on item state (e.g. blowgun vs blowtron).
         const questFlags = game.getState().flags.quest;
-        const itemId = GetInventoryMapping()[selectedSlot];
-        if (questFlags[itemId]) {
+        const rawItemId = GetInventoryMapping()[selectedSlot];
+        const resourceId = resolveItemResource(selectedSlot);
+        if (questFlags[rawItemId]) {
             getText(InventoryObjectsIndex).then((res) => {
-                setInvText(res[InventoryTextOffset + itemId].value);
+                setInvText(res[InventoryTextOffset + resourceId].value);
             });
         } else {
             setInvText('');
@@ -256,7 +292,8 @@ const Inventory = ({ game, closeInventory }: any) => {
             const slot = i * GetInventoryColumns() + j;
             const value = game.getState().flags.quest[GetInventoryMapping()[slot]];
             const inInventory = value >= 1;
-            const equipped = GetInventoryMapping()[slot] === equippedItem;
+            const itemId = resolveItem(slot);
+            const equipped = itemId === game.getState().hero.equippedItemId;
             inventorySlots.push(
                 <div
                   ref={itemNodes[slot]}

--- a/www/metadata/lba2/game.json
+++ b/www/metadata/lba2/game.json
@@ -20,7 +20,7 @@
       "type": "boolean"
     },
     {
-      "name": "incandescent_pearl",
+      "name": "incandescent_pearl_or_travel_token",
       "type": "boolean"
     },
     {
@@ -32,7 +32,7 @@
       "type": "boolean"
     },
     {
-      "name": "kashes"
+      "name": "kashes_or_zlitos"
     },
     {
       "name": "pisto_laser",
@@ -47,7 +47,8 @@
       "type": "boolean"
     },
     {
-      "name": "protopack"
+      "name": "protopack",
+      "type": "boolean"
     },
     {
       "name": "ferry_ticket",
@@ -57,7 +58,8 @@
       "name": "nitro_meca_penguin"
     },
     {
-      "name": "can_of_gazogem"
+      "name": "can_of_gazogem",
+      "type": "boolean"
     },
     {
       "name": "dissidents_ring",
@@ -87,10 +89,12 @@
       "type": "boolean"
     },
     {
-      "name": "blowgun"
+      "name": "blowgun",
+      "type": "boolean"
     },
     {
-      "name": "itinerary_token"
+      "name": "memory_viewer",
+      "type": "boolean"
     },
     {
       "name": "slice_of_tart",
@@ -117,7 +121,7 @@
       "type": "boolean"
     },
     {
-      "name": "fragment_of_the_francos",
+      "name": "fragment_of_the_francos_or_dark_monk_key",
       "type": "boolean"
     },
     {


### PR DESCRIPTION
In addition to using global vars to track items in Twinsen's inventory, each inventory slot also has a "state". This is used to determine which variant of an item Twinsen holds. The affected items are:

- robes vs wizard robes
- blowgun vs blowtron
- protopack vs jetpack
- etc

These changes implement support for tracking that state. Individual commit messages have details.

**Preview here:** https://pr-649.lba2remake.net