### PR TITLE
Fix hit_by condtions after hit opcode

### DIFF
--- a/src/game/scripting/life.ts
+++ b/src/game/scripting/life.ts
@@ -450,7 +450,7 @@ export function SUB_LIFE_POINT_OBJ(this: ScriptContext, actor: Actor, value) {
 }
 
 export function HIT(this: ScriptContext, actor: Actor, strength: number) {
-    actor.hit(this.actor, strength);
+    actor.hit(this.actor.index, strength);
 }
 
 export function PLAY_VIDEO(this: ScriptContext, cmdState, video: string) {


### PR DESCRIPTION
I broke this in a66144 when armour support was implemented.

**Preview here:** https://pr-650.lba2remake.net