### PR TITLE
Implement 'low collisions' mode for block collisions

### DIFF
--- a/src/game/scenery/isometric/IsoSceneryPhysics.ts
+++ b/src/game/scenery/isometric/IsoSceneryPhysics.ts
@@ -277,7 +277,8 @@ export default class IsoSceneryPhysics {
                 position,
                 dx,
                 dz,
-                isTouchingGround
+                isTouchingGround,
+                obj instanceof Actor && (obj as Actor).props.flags.hasCollisionBricksLow
             );
         }
         position.multiplyScalar(WORLD_SIZE);
@@ -397,7 +398,8 @@ function processBoxIntersections(
     position: THREE.Vector3,
     dx: number,
     dz: number,
-    isTouchingGround: boolean
+    isTouchingGround: boolean,
+    lowCollisions: boolean
 ) {
     const boundingBox = obj.model.boundingBox;
     ACTOR_BOX.copy(boundingBox);
@@ -405,6 +407,11 @@ function processBoxIntersections(
     ACTOR_BOX.max.multiplyScalar(STEP);
     ACTOR_BOX.translate(position);
     ACTOR_BOX.min.y += 1 / 128;
+
+    // The lowCollisions flag indicates crawling.
+    if (lowCollisions) {
+        ACTOR_BOX.max.y = ACTOR_BOX.min.y + (ACTOR_BOX.max.y - ACTOR_BOX.min.y) / 2;
+    }
 
     let collision = false;
     for (let ox = -1; ox < 2; ox += 1) {

--- a/src/ui/editor/areas/gameplay/scripts/blocks/blocksLibrary/life/actions.ts
+++ b/src/ui/editor/areas/gameplay/scripts/blocks/blocksLibrary/life/actions.ts
@@ -480,7 +480,7 @@ export const lba_set_can_fall = action((_block, field) => {
 });
 
 export const lba_brick_col = action((_block, field) => {
-    field('(?) brick_ ol');
+    field('brick_col');
     field(new Blockly.FieldNumber(), 'arg_0');
 });
 


### PR DESCRIPTION
Based on testing LBA2, low collisions mode (enabled when the brick collision mode is set to 2; 0 is disabled and 1 is enabled) is used when Twinsen crawls through a low passage. Without this mode, he gets stuck on the scenery.

This change arbitrarily halves the height of Twinsen's collision box in this mode, which seems to be enough to get him through.

A good place to test this is the passage between the weather wizard's tent and the sewers.