### PR TITLE
Fix issue with previous XXH implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "blockly": "^3.20200924.4",
         "color-convert": "^2.0.1",
         "file-saver": "^2.0.5",
+        "hash-wasm": "^4.9.0",
         "jest-diff": "^25.5.0",
         "jszip": "^3.7.0",
         "lodash": "^4.17.21",
@@ -27,8 +28,7 @@
         "sass-loader": "^12.3.0",
         "simplex-noise": "^2.4.0",
         "three": "^0.127.0",
-        "webxr-polyfill": "^2.0.3",
-        "xxhash-wasm": "^0.4.2"
+        "webxr-polyfill": "^2.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -4618,6 +4618,11 @@
       "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==",
       "dev": true
     },
+    "node_modules/hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
+    },
     "node_modules/hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -9091,11 +9096,6 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA=="
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -12900,6 +12900,11 @@
       "integrity": "sha512-Gjzu0Xn7IagXVkSu9cSFuK1fqzwtLwFhNhVL8IFJijRNMgUttFbBSIAzKuSIrsFMO1+g1RlsoN49zPIbwPDMGQ==",
       "dev": true
     },
+    "hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
+    },
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
@@ -16338,11 +16343,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "xxhash-wasm": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
-      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "blockly": "^3.20200924.4",
     "color-convert": "^2.0.1",
     "file-saver": "^2.0.5",
+    "hash-wasm": "^4.9.0",
     "jest-diff": "^25.5.0",
     "jszip": "^3.7.0",
     "lodash": "^4.17.21",
@@ -35,8 +36,7 @@
     "sass-loader": "^12.3.0",
     "simplex-noise": "^2.4.0",
     "three": "^0.127.0",
-    "webxr-polyfill": "^2.0.3",
-    "xxhash-wasm": "^0.4.2"
+    "webxr-polyfill": "^2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/src/game/scenery/isometric/metadata/replacements.ts
+++ b/src/game/scenery/isometric/metadata/replacements.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { each, last, find } from 'lodash';
-import XXH from 'xxhash-wasm';
+import { xxhash3 } from 'hash-wasm';
 
 import { loadLUTTexture } from '../../../../utils/lut';
 import { loadPaletteTexture } from '../../../../texture';
@@ -15,11 +15,6 @@ import { loadFullSceneModel } from './models';
 import { getCommonResource } from '../../../../resources';
 import { getPartialMatrixWorld } from '../../../../utils/math';
 import { GROUND_TYPES } from '../grid';
-
-let h32Raw;
-XXH().then((xxh) => {
-    h32Raw = xxh.h32Raw;
-});
 
 export async function initReplacements(
     entry,
@@ -70,13 +65,13 @@ export function applyReplacement(x, y, z, replacements, target) {
     const realZ = z - 1;
     suppressTargetBricks(replacements, target.data, x, y, z);
     if (replacements.mergeReplacements) {
-        addReplacementObject(
-            target.replacementData,
+        return {
+            info: target.replacementData,
             replacements,
-            x - (nX * 0.5) + 1,
-            realY - 0.5,
-            realZ - (nZ * 0.5) + 1
-        );
+            gx: x - (nX * 0.5) + 1,
+            gy: realY - 0.5,
+            gz: realZ - (nZ * 0.5) + 1
+        };
     }
 }
 
@@ -169,7 +164,7 @@ const angleMapping = [
 
 const identityMatrix = new THREE.Matrix4();
 
-async function addReplacementObject(info, replacements, gx, gy, gz) {
+export async function addReplacementObject({ info, replacements, gx, gy, gz }) {
     const { threeObject, animations, orientation } = info;
     const scale = 1 / 0.75;
     const angle = angleMapping[orientation];
@@ -263,12 +258,17 @@ async function addReplacementObject(info, replacements, gx, gy, gz) {
     animRoot.updateMatrix();
     animRoot.updateMatrixWorld(true);
 
+    const nodes = [];
+
     threeObject.traverse((node) => {
         if (skipMeshes.includes(node)) {
             return;
         }
         node.updateMatrix();
         node.updateMatrixWorld(true);
+        nodes.push(node);
+    });
+    for (const node of nodes) {
         for (const {binding, track} of bindings) {
             if (binding.node === node) {
                 if (node.parent !== threeObject) {
@@ -301,16 +301,16 @@ async function addReplacementObject(info, replacements, gx, gy, gz) {
             skip.add(node);
             if (node instanceof THREE.Mesh) {
                 const matrixWorld = getPartialMatrixWorld(node, last(animNodes).node);
-                appendMeshGeometry(
+                await appendMeshGeometry(
                     last(animNodes).data, identityMatrix, node, info, angle, matrixWorld
                 );
             }
             return;
         }
         if (node instanceof THREE.Mesh) {
-            appendMeshGeometry(replacements, gTransform, node, info, angle);
+            await appendMeshGeometry(replacements, gTransform, node, info, angle);
         }
-    });
+    }
     for (const {group, data} of animNodes) {
         buildReplacementMeshes({
             geometries: data.geometries,
@@ -329,7 +329,7 @@ const textureIdCache = {};
 const canvas = document.createElement('canvas');
 const context = canvas.getContext('2d');
 
-function appendMeshGeometry(
+async function appendMeshGeometry(
     {idCounters, geometries, data},
     gTransform,
     node,
@@ -378,7 +378,8 @@ function appendMeshGeometry(
             canvas.height = image.height;
             context.drawImage(image, 0, 0);
             const imageData = context.getImageData(0, 0, image.width, image.height);
-            const textureId = h32Raw(imageData.data.buffer, 0).toString(16);
+            const uint8Buffer = new Uint8Array(imageData.data.buffer);
+            const textureId = await xxhash3(uint8Buffer);
             textureIdCache[texture.uuid] = textureId;
             geomGroup = `textured_${textureId}`;
         }


### PR DESCRIPTION
For context: I'm using a hashing function on textures when compiling Iso 3D scenes, to group geomtries that use the same textures together (offers better batching).

It seems that xxhash-wasm's implementation was incorrect as it generated a big amount of collisions and different hashes from the previous one.
Switching to XXH3 hash function for faster results and less collisions. The async API forced me to refactor a few functions.